### PR TITLE
Add feature flags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,10 +11,17 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -25,21 +32,20 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       
+      # Setup Pages
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+      
       - name: Build documentation with all features
         run: cargo doc --no-deps --all-features --workspace
       
-      - name: Create index.html redirect
+      - name: Create index.html redirect and add custom CSS
         run: |
           echo '<meta http-equiv="refresh" content="0; url=kincir/index.html">' > target/doc/index.html
           cp rustdoc.css target/doc/rustdoc.css
           echo '<link rel="stylesheet" href="rustdoc.css">' >> target/doc/head.html
           
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v4
-        with:
-          enablement: true
-        
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -52,7 +58,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-    # Only deploy on pushes to the main branch
+    # Only deploy on pushes to the main branch or add-feature-flags branch
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/add-feature-flags')
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,11 +32,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       
-      # Setup Pages
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v4
-      
       - name: Build documentation with all features
         run: cargo doc --no-deps --all-features --workspace
       

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,8 +53,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-    # Only deploy on pushes to the main branch or add-feature-flags branch
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/add-feature-flags')
+    # Only deploy on pushes to the main branch
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v4
+        with:
+          enablement: true
         
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,58 @@
+name: Build and Deploy Docs
+
+on:
+  push:
+    branches: [main, add-feature-flags]
+  pull_request:
+    branches: [main]
+  # Allow manual triggering of the workflow
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    name: Build Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      
+      - name: Build documentation with all features
+        run: cargo doc --no-deps --all-features --workspace
+      
+      - name: Create index.html redirect
+        run: |
+          echo '<meta http-equiv="refresh" content="0; url=kincir/index.html">' > target/doc/index.html
+          cp rustdoc.css target/doc/rustdoc.css
+          echo '<link rel="stylesheet" href="rustdoc.css">' >> target/doc/head.html
+          
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+        
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './target/doc'
+          
+  deploy:
+    name: Deploy to GitHub Pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    # Only deploy on pushes to the main branch
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/add-feature-flags')
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6] - 2024-03-23
+
+### Added
+- Protocol Buffers (protobuf) encoding/decoding support via `protobuf` feature flag
+- New `MessageCodec` trait for message encoding and decoding 
+- `ProtobufCodec` implementation for efficient binary serialization
+- Example application for Protocol Buffers usage
+- Default implementations for various structs to follow Rust conventions
+
+### Fixed
+- Various Clippy warnings across the codebase
+- Proper implementation of ProstMessage trait for protocol buffer structs
+
+## [0.1.5] - 2024-03-22
+
+### Added
+- Optional logging with feature flag support
+- Default features now include logging
+- Improved documentation of feature flags
+
+### Changed
+- Refactored router implementation to work with or without logging
+- Made logging feature optional and configurable
+
+## [0.1.4] - 2024-03-20
+
 ### Added
 - Makefile for common development tasks
 - Docker and docker-compose support for development and testing
@@ -19,6 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated example applications to work in Docker environment
 - Updated README.md with build and Docker information
 
+### Fixed
+- Clippy warning in integration test
+
 ## [0.1.0] - 2023-02-18
 
 ### Added
@@ -28,4 +57,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Message UUID generation
 - Metadata support
 - Logging support
-- Example applications 
+- Example applications

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ resolver = "2"
 members = [
     "kincir",
     "examples/kafka-example",
-    "examples/rabbitmq-example"
+    "examples/rabbitmq-example",
+    "examples/protobuf-example"
 ]
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Kincir
 
+<!-- 
+GitHub Pages Setup:
+1. Go to repository Settings > Pages
+2. Under "Build and deployment" > "Source", select "GitHub Actions"
+3. This will enable GitHub Pages for this repository
+-->
+
 [![Crates.io](https://img.shields.io/crates/v/kincir.svg)](https://crates.io/crates/kincir)
 [![Documentation](https://docs.rs/kincir/badge.svg)](https://docs.rs/kincir)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)

--- a/examples/kafka-example/src/main.rs
+++ b/examples/kafka-example/src/main.rs
@@ -1,5 +1,5 @@
 use kincir::kafka::{KafkaPublisher, KafkaSubscriber};
-use kincir::router::StdLogger;
+use kincir::logging::StdLogger;
 use kincir::{HandlerFunc, Message, Router};
 use std::sync::Arc;
 use tokio::sync::mpsc;

--- a/examples/protobuf-example/Cargo.toml
+++ b/examples/protobuf-example/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "protobuf-example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+kincir = { path = "../../kincir", features = ["protobuf"] }
+tokio = { version = "1.36", features = ["full"] }
+chrono = "0.4" 

--- a/examples/protobuf-example/src/main.rs
+++ b/examples/protobuf-example/src/main.rs
@@ -1,0 +1,47 @@
+use kincir::Message;
+use kincir::protobuf::{MessageCodec, ProtobufCodec};
+
+fn main() {
+    // Create a message with payload and metadata
+    let original_message = Message::new(b"Hello, Protocol Buffers!".to_vec())
+        .with_metadata("content-type", "text/plain")
+        .with_metadata("priority", "high")
+        .with_metadata("timestamp", &chrono::Utc::now().to_rfc3339());
+    
+    println!("Original message:");
+    println!("  UUID: {}", original_message.uuid);
+    println!("  Payload: {} bytes", original_message.payload.len());
+    println!("  Metadata entries: {}", original_message.metadata.len());
+    
+    // Create a protobuf codec
+    let codec = ProtobufCodec::new();
+    
+    // Encode the message
+    let encoded = codec.encode(&original_message).unwrap();
+    println!("\nMessage encoded to {} bytes using Protocol Buffers", encoded.len());
+    
+    // Decode the message
+    let decoded_message = codec.decode(&encoded).unwrap();
+    
+    // Verify the decoded message matches the original
+    println!("\nDecoded message:");
+    println!("  UUID: {}", decoded_message.uuid);
+    println!("  Payload: {} bytes", decoded_message.payload.len());
+    println!("  Metadata entries: {}", decoded_message.metadata.len());
+    
+    // Check if the messages are equivalent
+    let uuid_match = original_message.uuid == decoded_message.uuid;
+    let payload_match = original_message.payload == decoded_message.payload;
+    let metadata_match = original_message.metadata == decoded_message.metadata;
+    
+    println!("\nVerification:");
+    println!("  UUID match: {}", uuid_match);
+    println!("  Payload match: {}", payload_match);
+    println!("  Metadata match: {}", metadata_match);
+    
+    if uuid_match && payload_match && metadata_match {
+        println!("\nSuccess! The message was correctly encoded and decoded using Protocol Buffers.");
+    } else {
+        println!("\nError: The decoded message doesn't match the original.");
+    }
+} 

--- a/examples/protobuf-example/src/main.rs
+++ b/examples/protobuf-example/src/main.rs
@@ -1,5 +1,5 @@
-use kincir::Message;
 use kincir::protobuf::{MessageCodec, ProtobufCodec};
+use kincir::Message;
 
 fn main() {
     // Create a message with payload and metadata
@@ -7,41 +7,46 @@ fn main() {
         .with_metadata("content-type", "text/plain")
         .with_metadata("priority", "high")
         .with_metadata("timestamp", &chrono::Utc::now().to_rfc3339());
-    
+
     println!("Original message:");
     println!("  UUID: {}", original_message.uuid);
     println!("  Payload: {} bytes", original_message.payload.len());
     println!("  Metadata entries: {}", original_message.metadata.len());
-    
+
     // Create a protobuf codec
     let codec = ProtobufCodec::new();
-    
+
     // Encode the message
     let encoded = codec.encode(&original_message).unwrap();
-    println!("\nMessage encoded to {} bytes using Protocol Buffers", encoded.len());
-    
+    println!(
+        "\nMessage encoded to {} bytes using Protocol Buffers",
+        encoded.len()
+    );
+
     // Decode the message
     let decoded_message = codec.decode(&encoded).unwrap();
-    
+
     // Verify the decoded message matches the original
     println!("\nDecoded message:");
     println!("  UUID: {}", decoded_message.uuid);
     println!("  Payload: {} bytes", decoded_message.payload.len());
     println!("  Metadata entries: {}", decoded_message.metadata.len());
-    
+
     // Check if the messages are equivalent
     let uuid_match = original_message.uuid == decoded_message.uuid;
     let payload_match = original_message.payload == decoded_message.payload;
     let metadata_match = original_message.metadata == decoded_message.metadata;
-    
+
     println!("\nVerification:");
     println!("  UUID match: {}", uuid_match);
     println!("  Payload match: {}", payload_match);
     println!("  Metadata match: {}", metadata_match);
-    
+
     if uuid_match && payload_match && metadata_match {
-        println!("\nSuccess! The message was correctly encoded and decoded using Protocol Buffers.");
+        println!(
+            "\nSuccess! The message was correctly encoded and decoded using Protocol Buffers."
+        );
     } else {
         println!("\nError: The decoded message doesn't match the original.");
     }
-} 
+}

--- a/examples/protobuf-example/src/main.rs
+++ b/examples/protobuf-example/src/main.rs
@@ -6,7 +6,7 @@ fn main() {
     let original_message = Message::new(b"Hello, Protocol Buffers!".to_vec())
         .with_metadata("content-type", "text/plain")
         .with_metadata("priority", "high")
-        .with_metadata("timestamp", &chrono::Utc::now().to_rfc3339());
+        .with_metadata("timestamp", chrono::Utc::now().to_rfc3339());
 
     println!("Original message:");
     println!("  UUID: {}", original_message.uuid);

--- a/examples/rabbitmq-example/src/main.rs
+++ b/examples/rabbitmq-example/src/main.rs
@@ -1,5 +1,5 @@
 use kincir::rabbitmq::{RabbitMQPublisher, RabbitMQSubscriber};
-use kincir::router::StdLogger;
+use kincir::logging::StdLogger;
 use kincir::{HandlerFunc, Message, Router};
 use std::sync::Arc;
 

--- a/examples/rabbitmq-example/src/main.rs
+++ b/examples/rabbitmq-example/src/main.rs
@@ -1,5 +1,5 @@
-use kincir::rabbitmq::{RabbitMQPublisher, RabbitMQSubscriber};
 use kincir::logging::StdLogger;
+use kincir::rabbitmq::{RabbitMQPublisher, RabbitMQSubscriber};
 use kincir::{HandlerFunc, Message, Router};
 use std::sync::Arc;
 

--- a/kincir/Cargo.toml
+++ b/kincir/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rezacute/kincir"
 [features]
 default = ["logging"]
 logging = []
+protobuf = ["prost"]
 
 [dependencies]
 tokio = { version = "1.36", features = ["full"] }
@@ -24,6 +25,7 @@ serde_json = "1.0"
 futures = "0.3"
 uuid = { version = "1.7", features = ["v4"] }
 bincode = "1.3"
+prost = { version = "0.12", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/kincir/Cargo.toml
+++ b/kincir/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
 name = "kincir"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "A Rust message streaming library inspired by Watermill"
 license = "MIT"
 authors = ["Riza Alaudin Syah <rezaqt@gmail.com>"]
 repository = "https://github.com/rezacute/kincir"
+
+[features]
+default = ["logging"]
+logging = []
 
 [dependencies]
 tokio = { version = "1.36", features = ["full"] }

--- a/kincir/Cargo.toml
+++ b/kincir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kincir"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "A Rust message streaming library inspired by Watermill"
 license = "MIT"

--- a/kincir/README.md
+++ b/kincir/README.md
@@ -22,7 +22,7 @@ Add kincir to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-kincir = "0.1.5"
+kincir = "0.1.6"
 ```
 
 ### Feature Flags
@@ -32,19 +32,19 @@ Kincir provides feature flags to customize the library:
 ```toml
 [dependencies]
 # Default features (includes logging)
-kincir = "0.1.5"
+kincir = "0.1.6"
 
 # Without logging
-kincir = { version = "0.1.5", default-features = false }
+kincir = { version = "0.1.6", default-features = false }
 
 # Explicitly enable logging
-kincir = { version = "0.1.5", features = ["logging"] }
+kincir = { version = "0.1.6", features = ["logging"] }
 
 # With Protocol Buffers support
-kincir = { version = "0.1.5", features = ["protobuf"] }
+kincir = { version = "0.1.6", features = ["protobuf"] }
 
 # With both logging and Protocol Buffers
-kincir = { version = "0.1.5", features = ["logging", "protobuf"] }
+kincir = { version = "0.1.6", features = ["logging", "protobuf"] }
 ```
 
 ## Build and Development

--- a/kincir/README.md
+++ b/kincir/README.md
@@ -6,6 +6,8 @@
 
 Kincir is a Rust library that provides a unified interface for message streaming with support for multiple message broker backends. It offers a simple, consistent API for publishing and subscribing to messages across different messaging systems, with advanced routing capabilities.
 
+**[📚 Online Documentation](https://rezacute.github.io/kincir/) | [🦀 Crates.io](https://crates.io/crates/kincir) | [💻 GitHub Repository](https://github.com/rezacute/kincir)**
+
 ## Features
 
 - Unified messaging interface with support for multiple backends (Kafka, RabbitMQ)

--- a/kincir/README.md
+++ b/kincir/README.md
@@ -39,6 +39,12 @@ kincir = { version = "0.1.5", default-features = false }
 
 # Explicitly enable logging
 kincir = { version = "0.1.5", features = ["logging"] }
+
+# With Protocol Buffers support
+kincir = { version = "0.1.5", features = ["protobuf"] }
+
+# With both logging and Protocol Buffers
+kincir = { version = "0.1.5", features = ["logging", "protobuf"] }
 ```
 
 ## Build and Development
@@ -273,6 +279,30 @@ Each message in Kincir consists of:
 - `payload`: The actual message content as a byte vector
 - `metadata`: A hash map of string key-value pairs for additional message information
 
+## Message Encoding and Decoding
+
+### Protocol Buffers Support
+
+When the `protobuf` feature is enabled, Kincir provides Protocol Buffers encoding/decoding capabilities:
+
+```rust
+use kincir::Message;
+use kincir::protobuf::{MessageCodec, ProtobufCodec};
+
+// Create a protobuf codec
+let codec = ProtobufCodec::new();
+
+// Create a message
+let message = Message::new(b"Hello".to_vec())
+    .with_metadata("content-type", "text/plain");
+
+// Encode the message to send over the wire
+let encoded = codec.encode(&message).unwrap();
+
+// Later, decode the message
+let decoded = codec.decode(&encoded).unwrap();
+```
+
 ## Message Handler
 
 Message handlers are async functions that process incoming messages and can produce zero or more output messages:
@@ -290,6 +320,38 @@ let handler = |msg: Message| {
     })
 };
 ```
+
+### Protocol Buffers Support
+
+When the `protobuf` feature flag is enabled, Kincir provides support for encoding and decoding messages using Protocol Buffers through the `MessageCodec` trait:
+
+```rust
+#[cfg(feature = "protobuf")]
+use kincir::{Message, MessageCodec, ProtobufCodec};
+
+// Create a message
+let message = Message::new(b"Hello, Protocol Buffers!".to_vec())
+    .with_metadata("encoding", "protobuf");
+
+// Create a Protocol Buffers codec
+let codec = ProtobufCodec::new();
+
+// Encode the message to Protocol Buffers binary format
+let encoded = codec.encode(&message).unwrap();
+
+// Decode the binary data back to a Message
+let decoded = codec.decode(&encoded).unwrap();
+
+assert_eq!(message.uuid, decoded.uuid);
+assert_eq!(message.payload, decoded.payload);
+assert_eq!(message.metadata, decoded.metadata);
+```
+
+This is particularly useful when you need:
+- Smaller message size compared to JSON
+- Stricter schema validation
+- Better performance for serialization and deserialization
+- Language-agnostic message exchange
 
 ## Roadmap to v1.0 🚀  
 

--- a/kincir/src/kafka.rs
+++ b/kincir/src/kafka.rs
@@ -5,7 +5,7 @@
 //! for message passing and includes proper error handling.
 //!
 //! The functionality varies depending on feature flags:
-//! 
+//!
 //! - With the "logging" feature enabled, logging is integrated throughout the components
 //! - Without the "logging" feature, operations proceed without logging
 //!
@@ -59,9 +59,9 @@
 //! # }
 //! ```
 
-use crate::Message;
 #[cfg(feature = "logging")]
 use crate::logging::Logger;
+use crate::Message;
 use async_trait::async_trait;
 use std::sync::Arc;
 use thiserror::Error;
@@ -211,11 +211,7 @@ impl KafkaSubscriber {
     /// * `_brokers` - List of Kafka broker addresses
     /// * `_group_id` - Consumer group ID
     /// * `rx` - Channel receiver for messages
-    pub fn new(
-        _brokers: Vec<String>,
-        _group_id: String,
-        rx: mpsc::Receiver<Message>,
-    ) -> Self {
+    pub fn new(_brokers: Vec<String>, _group_id: String, rx: mpsc::Receiver<Message>) -> Self {
         Self {
             rx: Arc::new(tokio::sync::Mutex::new(rx)),
         }

--- a/kincir/src/kafka.rs
+++ b/kincir/src/kafka.rs
@@ -57,7 +57,6 @@
 //!
 //! # Ok(())
 //! # }
-//! ```
 
 #[cfg(feature = "logging")]
 use crate::logging::Logger;

--- a/kincir/src/lib.rs
+++ b/kincir/src/lib.rs
@@ -21,7 +21,7 @@
 //! use kincir::rabbitmq::{RabbitMQPublisher, RabbitMQSubscriber};
 //! use kincir::router::Router;
 //! use std::sync::Arc;
-//! 
+//!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 //! // Create and configure components
 //! let publisher = Arc::new(RabbitMQPublisher::new("amqp://localhost:5672").await?);
@@ -34,7 +34,7 @@
 //!         Ok(vec![processed_msg])
 //!     })
 //! });
-//! 
+//!
 //! // Set up and run router (with or without logging based on feature)
 //! # #[cfg(feature = "logging")]
 //! # {
@@ -44,7 +44,7 @@
 //! let router = Router::new(
 //!     logger,
 //!     "input-queue".to_string(),
-//!     "output-queue".to_string(), 
+//!     "output-queue".to_string(),
 //!     subscriber.clone(),
 //!     publisher.clone(),
 //!     handler.clone(),
@@ -61,7 +61,7 @@
 //!     handler,
 //! );
 //! # }
-//! 
+//!
 //! router.run().await
 //! # }
 //! ```
@@ -161,9 +161,9 @@ pub mod logging;
 pub mod protobuf;
 
 // Re-export commonly used types
-pub use router::HandlerFunc;
-pub use router::Router;
 #[cfg(feature = "logging")]
 pub use logging::{Logger, NoOpLogger, StdLogger};
 #[cfg(feature = "protobuf")]
 pub use protobuf::{MessageCodec, ProtobufCodec};
+pub use router::HandlerFunc;
+pub use router::Router;

--- a/kincir/src/lib.rs
+++ b/kincir/src/lib.rs
@@ -21,14 +21,16 @@
 //! use kincir::rabbitmq::{RabbitMQPublisher, RabbitMQSubscriber};
 //! use kincir::router::Router;
 //! use std::sync::Arc;
+//! use std::pin::Pin;
+//! use std::future::Future;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 //! // Create and configure components
 //! let publisher = Arc::new(RabbitMQPublisher::new("amqp://localhost:5672").await?);
 //! let subscriber = Arc::new(RabbitMQSubscriber::new("amqp://localhost:5672").await?);
 //!
-//! // Define message handler
-//! let handler = Arc::new(|msg: Message| {
+//! // Define message handler with explicit type signature
+//! let handler = Arc::new(|msg: Message| -> Pin<Box<dyn Future<Output = Result<Vec<Message>, Box<dyn std::error::Error + Send + Sync>>> + Send>> {
 //!     Box::pin(async move {
 //!         let processed_msg = msg.with_metadata("processed", "true");
 //!         Ok(vec![processed_msg])
@@ -49,6 +51,8 @@
 //!     publisher.clone(),
 //!     handler.clone(),
 //! );
+//!
+//! router.run().await
 //! # }
 //! # #[cfg(not(feature = "logging"))]
 //! # {
@@ -60,9 +64,9 @@
 //!     publisher,
 //!     handler,
 //! );
-//! # }
 //!
 //! router.run().await
+//! # }
 //! # }
 //! ```
 

--- a/kincir/src/lib.rs
+++ b/kincir/src/lib.rs
@@ -5,49 +5,63 @@
 //! - A unified API for publishing and subscribing to messages
 //! - Support for multiple message broker backends (Kafka, RabbitMQ)
 //! - Message routing with customizable handlers
-//! - Built-in logging capabilities
 //! - Message tracking with UUID generation
 //! - Extensible message metadata
 //!
-//! # Quick Start
+//! When the "logging" feature is enabled (default), Kincir also provides built-in logging capabilities.
+//!
+//! # Example
+//!
+//! Basic usage with RabbitMQ backend:
 //!
 //! ```rust,no_run
-//! use kincir::rabbitmq::{RabbitMQPublisher, RabbitMQSubscriber};
-//! use kincir::router::{Router, Logger, StdLogger};
 //! use kincir::Message;
+//! use kincir::rabbitmq::{RabbitMQPublisher, RabbitMQSubscriber};
+//! use kincir::router::Router;
 //! use std::sync::Arc;
-//! use std::pin::Pin;
-//! use std::future::Future;
+//! 
+//! # async fn example() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+//! // Create and configure components
+//! let publisher = Arc::new(RabbitMQPublisher::new("amqp://localhost:5672").await?);
+//! let subscriber = Arc::new(RabbitMQSubscriber::new("amqp://localhost:5672").await?);
 //!
-//! #[tokio::main]
-//! async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-//!     // Initialize components
-//!     let logger = Arc::new(StdLogger::new(true, true));
-//!     let publisher = Arc::new(RabbitMQPublisher::new("amqp://localhost:5672").await?);
-//!     let subscriber = Arc::new(RabbitMQSubscriber::new("amqp://localhost:5672").await?);
-//!
-//!     // Create message handler
-//!     let handler = Arc::new(|msg: Message| -> Pin<Box<dyn Future<Output = Result<Vec<Message>, Box<dyn std::error::Error + Send + Sync>>> + Send>> {
-//!         Box::pin(async move {
-//!             // Process the message
-//!             let mut processed_msg = msg;
-//!             processed_msg.metadata.insert("processed".to_string(), "true".to_string());
-//!             Ok(vec![processed_msg])
-//!         })
-//!     });
-//!
-//!     // Set up and run the router
-//!     let router = Router::new(
-//!         logger,
-//!         "input-queue".to_string(),
-//!         "output-queue".to_string(),
-//!         subscriber,
-//!         publisher,
-//!         handler,
-//!     );
-//!
-//!     router.run().await
-//! }
+//! // Define message handler
+//! let handler = Arc::new(|msg: Message| {
+//!     Box::pin(async move {
+//!         let processed_msg = msg.with_metadata("processed", "true");
+//!         Ok(vec![processed_msg])
+//!     })
+//! });
+//! 
+//! // Set up and run router (with or without logging based on feature)
+//! # #[cfg(feature = "logging")]
+//! # {
+//! // With logging (when "logging" feature is enabled)
+//! use kincir::logging::{Logger, StdLogger};
+//! let logger = Arc::new(StdLogger::new(true, true));
+//! let router = Router::new(
+//!     logger,
+//!     "input-queue".to_string(),
+//!     "output-queue".to_string(), 
+//!     subscriber.clone(),
+//!     publisher.clone(),
+//!     handler.clone(),
+//! );
+//! # }
+//! # #[cfg(not(feature = "logging"))]
+//! # {
+//! // Without logging (when "logging" feature is disabled)
+//! let router = Router::new(
+//!     "input-queue".to_string(),
+//!     "output-queue".to_string(),
+//!     subscriber,
+//!     publisher,
+//!     handler,
+//! );
+//! # }
+//! 
+//! router.run().await
+//! # }
 //! ```
 
 use async_trait::async_trait;
@@ -138,5 +152,11 @@ pub mod kafka;
 pub mod rabbitmq;
 pub mod router;
 
+#[cfg(feature = "logging")]
+pub mod logging;
+
 // Re-export commonly used types
-pub use router::{HandlerFunc, Logger, Router, StdLogger};
+pub use router::HandlerFunc;
+pub use router::Router;
+#[cfg(feature = "logging")]
+pub use logging::{Logger, NoOpLogger, StdLogger};

--- a/kincir/src/lib.rs
+++ b/kincir/src/lib.rs
@@ -10,6 +10,8 @@
 //!
 //! When the "logging" feature is enabled (default), Kincir also provides built-in logging capabilities.
 //!
+//! When the "protobuf" feature is enabled, Kincir provides Protocol Buffers encoding/decoding capabilities.
+//!
 //! # Example
 //!
 //! Basic usage with RabbitMQ backend:
@@ -155,8 +157,13 @@ pub mod router;
 #[cfg(feature = "logging")]
 pub mod logging;
 
+#[cfg(feature = "protobuf")]
+pub mod protobuf;
+
 // Re-export commonly used types
 pub use router::HandlerFunc;
 pub use router::Router;
 #[cfg(feature = "logging")]
 pub use logging::{Logger, NoOpLogger, StdLogger};
+#[cfg(feature = "protobuf")]
+pub use protobuf::{MessageCodec, ProtobufCodec};

--- a/kincir/src/logging.rs
+++ b/kincir/src/logging.rs
@@ -86,6 +86,12 @@ impl NoOpLogger {
     }
 }
 
+impl Default for NoOpLogger {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[async_trait]
 impl Logger for NoOpLogger {
     async fn info(&self, _msg: &str) {

--- a/kincir/src/logging.rs
+++ b/kincir/src/logging.rs
@@ -1,0 +1,98 @@
+//! Logging functionality for the Kincir messaging system.
+//!
+//! This module provides logging capabilities that can be used throughout
+//! the Kincir library. It includes:
+//!
+//! - A `Logger` trait for customizable logging
+//! - A standard logger implementation (`StdLogger`)
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use kincir::logging::{Logger, StdLogger};
+//! use std::sync::Arc;
+//!
+//! // Create a logger that shows both info and error messages
+//! let logger = Arc::new(StdLogger::new(true, true));
+//!
+//! // Use the logger
+//! # async fn example(logger: Arc<StdLogger>) {
+//! logger.info("This is an informational message").await;
+//! logger.error("This is an error message").await;
+//! # }
+//! ```
+
+use async_trait::async_trait;
+
+/// Defines the interface for logging operations in the router.
+#[async_trait]
+pub trait Logger: Send + Sync {
+    /// Logs an informational message.
+    async fn info(&self, msg: &str);
+    /// Logs an error message.
+    async fn error(&self, msg: &str);
+}
+
+/// A standard implementation of the Logger trait that writes to stdout/stderr.
+///
+/// This logger provides basic logging capabilities with configurable output levels.
+pub struct StdLogger {
+    /// Whether to show informational messages
+    show_info: bool,
+    /// Whether to show error messages
+    show_error: bool,
+}
+
+impl StdLogger {
+    /// Creates a new StdLogger with configurable output levels.
+    ///
+    /// # Arguments
+    ///
+    /// * `show_info` - Whether to display informational messages
+    /// * `show_error` - Whether to display error messages
+    pub fn new(show_info: bool, show_error: bool) -> Self {
+        Self {
+            show_info,
+            show_error,
+        }
+    }
+}
+
+#[async_trait]
+impl Logger for StdLogger {
+    async fn info(&self, msg: &str) {
+        if self.show_info {
+            println!("[INFO] {}", msg);
+        }
+    }
+
+    async fn error(&self, msg: &str) {
+        if self.show_error {
+            eprintln!("[ERROR] {}", msg);
+        }
+    }
+}
+
+/// A no-op logger implementation that does nothing.
+///
+/// This logger can be used when logging is not required, and all logging
+/// calls will be effectively no-ops.
+pub struct NoOpLogger;
+
+impl NoOpLogger {
+    /// Creates a new NoOpLogger.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Logger for NoOpLogger {
+    async fn info(&self, _msg: &str) {
+        // Do nothing
+    }
+
+    async fn error(&self, _msg: &str) {
+        // Do nothing
+    }
+} 

--- a/kincir/src/logging.rs
+++ b/kincir/src/logging.rs
@@ -95,4 +95,4 @@ impl Logger for NoOpLogger {
     async fn error(&self, _msg: &str) {
         // Do nothing
     }
-} 
+}

--- a/kincir/src/protobuf.rs
+++ b/kincir/src/protobuf.rs
@@ -1,0 +1,272 @@
+//! Protocol Buffers (protobuf) encoding and decoding for Kincir messages.
+//!
+//! This module provides support for encoding and decoding messages using Protocol Buffers.
+//! It defines a `MessageCodec` trait for encoding/decoding operations and implementations 
+//! for protobuf serialization.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use kincir::Message;
+//! use kincir::protobuf::{MessageCodec, ProtobufCodec};
+//!
+//! // Create a protobuf codec
+//! let codec = ProtobufCodec::new();
+//!
+//! // Encode a message
+//! let msg = Message::new(b"Hello, World!".to_vec());
+//! let encoded = codec.encode(&msg).unwrap();
+//!
+//! // Decode a message
+//! let decoded = codec.decode(&encoded).unwrap();
+//! ```
+
+use crate::Message;
+use prost::Message as ProstMessage;
+use thiserror::Error;
+use std::fmt::Debug;
+
+/// Represents possible errors that can occur in protobuf encoding/decoding operations.
+#[derive(Error, Debug)]
+pub enum ProtobufError {
+    /// Error when encoding a message
+    #[error("Encoding error: {0}")]
+    Encode(String),
+    /// Error when decoding a message
+    #[error("Decoding error: {0}")]
+    Decode(String),
+}
+
+/// A trait for message encoding and decoding operations.
+pub trait MessageCodec {
+    /// The type of error that can occur during encoding/decoding operations.
+    type Error;
+
+    /// Encodes a message into a byte vector.
+    fn encode(&self, message: &Message) -> Result<Vec<u8>, Self::Error>;
+
+    /// Decodes a byte vector into a message.
+    fn decode(&self, bytes: &[u8]) -> Result<Message, Self::Error>;
+}
+
+/// Protocol Buffer implementation of a message codec.
+///
+/// Uses Protocol Buffers for message serialization and deserialization.
+pub struct ProtobufCodec;
+
+/// The Protocol Buffer representation of a Message.
+#[derive(Clone, PartialEq, Debug)]
+pub struct ProtoMessage {
+    /// Unique identifier for the message
+    pub uuid: String,
+    /// The actual message content as bytes
+    pub payload: Vec<u8>,
+    /// Additional key-value pairs associated with the message
+    pub metadata: Vec<MetadataEntry>,
+}
+
+/// A single key-value entry in the message metadata.
+#[derive(Clone, PartialEq, Debug)]
+pub struct MetadataEntry {
+    /// The key of the metadata entry
+    pub key: String,
+    /// The value of the metadata entry
+    pub value: String,
+}
+
+impl ProstMessage for ProtoMessage {
+    fn encode_raw<B>(&self, buf: &mut B) 
+    where
+        B: prost::bytes::BufMut,
+    {
+        // Encode uuid (field 1)
+        prost::encoding::string::encode(1, &self.uuid, buf);
+        
+        // Encode payload (field 2)
+        prost::encoding::bytes::encode(2, &self.payload, buf);
+        
+        // Encode metadata entries (field 3)
+        for entry in &self.metadata {
+            prost::encoding::message::encode(3, entry, buf);
+        }
+    }
+    
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: prost::encoding::WireType,
+        buf: &mut B,
+        ctx: prost::encoding::DecodeContext,
+    ) -> Result<(), prost::DecodeError>
+    where
+        B: prost::bytes::Buf,
+    {
+        match tag {
+            1 => prost::encoding::string::merge(wire_type, &mut self.uuid, buf, ctx),
+            2 => prost::encoding::bytes::merge(wire_type, &mut self.payload, buf, ctx),
+            3 => {
+                let mut entry = MetadataEntry::default();
+                prost::encoding::message::merge(wire_type, &mut entry, buf, ctx)?;
+                self.metadata.push(entry);
+                Ok(())
+            }
+            _ => prost::encoding::skip_field(wire_type, tag, buf, ctx),
+        }
+    }
+    
+    fn encoded_len(&self) -> usize {
+        prost::encoding::string::encoded_len(1, &self.uuid) +
+        prost::encoding::bytes::encoded_len(2, &self.payload) +
+        self.metadata.iter().map(|entry| {
+            prost::encoding::message::encoded_len(3, entry)
+        }).sum::<usize>()
+    }
+    
+    fn clear(&mut self) {
+        self.uuid.clear();
+        self.payload.clear();
+        self.metadata.clear();
+    }
+}
+
+impl Default for ProtoMessage {
+    fn default() -> Self {
+        Self {
+            uuid: String::new(),
+            payload: Vec::new(),
+            metadata: Vec::new(),
+        }
+    }
+}
+
+impl ProstMessage for MetadataEntry {
+    fn encode_raw<B>(&self, buf: &mut B) 
+    where
+        B: prost::bytes::BufMut,
+    {
+        // Encode key (field 1)
+        prost::encoding::string::encode(1, &self.key, buf);
+        
+        // Encode value (field 2)
+        prost::encoding::string::encode(2, &self.value, buf);
+    }
+    
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: prost::encoding::WireType,
+        buf: &mut B,
+        ctx: prost::encoding::DecodeContext,
+    ) -> Result<(), prost::DecodeError>
+    where
+        B: prost::bytes::Buf,
+    {
+        match tag {
+            1 => prost::encoding::string::merge(wire_type, &mut self.key, buf, ctx),
+            2 => prost::encoding::string::merge(wire_type, &mut self.value, buf, ctx),
+            _ => prost::encoding::skip_field(wire_type, tag, buf, ctx),
+        }
+    }
+    
+    fn encoded_len(&self) -> usize {
+        prost::encoding::string::encoded_len(1, &self.key) +
+        prost::encoding::string::encoded_len(2, &self.value)
+    }
+    
+    fn clear(&mut self) {
+        self.key.clear();
+        self.value.clear();
+    }
+}
+
+impl Default for MetadataEntry {
+    fn default() -> Self {
+        Self {
+            key: String::new(),
+            value: String::new(),
+        }
+    }
+}
+
+impl ProtobufCodec {
+    /// Creates a new Protocol Buffer codec.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Converts a Kincir Message to a ProtoMessage.
+    fn message_to_proto(&self, message: &Message) -> ProtoMessage {
+        let metadata = message
+            .metadata
+            .iter()
+            .map(|(k, v)| MetadataEntry {
+                key: k.clone(),
+                value: v.clone(),
+            })
+            .collect();
+
+        ProtoMessage {
+            uuid: message.uuid.clone(),
+            payload: message.payload.clone(),
+            metadata,
+        }
+    }
+
+    /// Converts a ProtoMessage to a Kincir Message.
+    fn proto_to_message(&self, proto: ProtoMessage) -> Message {
+        let mut message = Message::new(proto.payload);
+        message.uuid = proto.uuid;
+
+        for entry in proto.metadata {
+            message.metadata.insert(entry.key, entry.value);
+        }
+
+        message
+    }
+}
+
+impl MessageCodec for ProtobufCodec {
+    type Error = ProtobufError;
+
+    fn encode(&self, message: &Message) -> Result<Vec<u8>, Self::Error> {
+        let proto = self.message_to_proto(message);
+        let mut buf = Vec::new();
+        
+        proto.encode(&mut buf)
+            .map_err(|e| ProtobufError::Encode(e.to_string()))?;
+        Ok(buf)
+    }
+
+    fn decode(&self, bytes: &[u8]) -> Result<Message, Self::Error> {
+        let proto = ProtoMessage::decode(bytes)
+            .map_err(|e| ProtobufError::Decode(e.to_string()))?;
+            
+        Ok(self.proto_to_message(proto))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_protobuf_codec_roundtrip() {
+        // Create a message with metadata
+        let mut original = Message::new(b"Hello, Protobuf!".to_vec());
+        original = original
+            .with_metadata("content-type", "text/plain")
+            .with_metadata("priority", "high");
+            
+        // Create codec
+        let codec = ProtobufCodec::new();
+        
+        // Encode and decode
+        let encoded = codec.encode(&original).unwrap();
+        let decoded = codec.decode(&encoded).unwrap();
+        
+        // Verify
+        assert_eq!(original.uuid, decoded.uuid);
+        assert_eq!(original.payload, decoded.payload);
+        assert_eq!(original.metadata, decoded.metadata);
+    }
+} 

--- a/kincir/src/protobuf.rs
+++ b/kincir/src/protobuf.rs
@@ -1,7 +1,7 @@
 //! Protocol Buffers (protobuf) encoding and decoding for Kincir messages.
 //!
 //! This module provides support for encoding and decoding messages using Protocol Buffers.
-//! It defines a `MessageCodec` trait for encoding/decoding operations and implementations 
+//! It defines a `MessageCodec` trait for encoding/decoding operations and implementations
 //! for protobuf serialization.
 //!
 //! # Example
@@ -23,8 +23,8 @@
 
 use crate::Message;
 use prost::Message as ProstMessage;
-use thiserror::Error;
 use std::fmt::Debug;
+use thiserror::Error;
 
 /// Represents possible errors that can occur in protobuf encoding/decoding operations.
 #[derive(Error, Debug)]
@@ -75,22 +75,22 @@ pub struct MetadataEntry {
 }
 
 impl ProstMessage for ProtoMessage {
-    fn encode_raw<B>(&self, buf: &mut B) 
+    fn encode_raw<B>(&self, buf: &mut B)
     where
         B: prost::bytes::BufMut,
     {
         // Encode uuid (field 1)
         prost::encoding::string::encode(1, &self.uuid, buf);
-        
+
         // Encode payload (field 2)
         prost::encoding::bytes::encode(2, &self.payload, buf);
-        
+
         // Encode metadata entries (field 3)
         for entry in &self.metadata {
             prost::encoding::message::encode(3, entry, buf);
         }
     }
-    
+
     fn merge_field<B>(
         &mut self,
         tag: u32,
@@ -113,15 +113,17 @@ impl ProstMessage for ProtoMessage {
             _ => prost::encoding::skip_field(wire_type, tag, buf, ctx),
         }
     }
-    
+
     fn encoded_len(&self) -> usize {
-        prost::encoding::string::encoded_len(1, &self.uuid) +
-        prost::encoding::bytes::encoded_len(2, &self.payload) +
-        self.metadata.iter().map(|entry| {
-            prost::encoding::message::encoded_len(3, entry)
-        }).sum::<usize>()
+        prost::encoding::string::encoded_len(1, &self.uuid)
+            + prost::encoding::bytes::encoded_len(2, &self.payload)
+            + self
+                .metadata
+                .iter()
+                .map(|entry| prost::encoding::message::encoded_len(3, entry))
+                .sum::<usize>()
     }
-    
+
     fn clear(&mut self) {
         self.uuid.clear();
         self.payload.clear();
@@ -140,17 +142,17 @@ impl Default for ProtoMessage {
 }
 
 impl ProstMessage for MetadataEntry {
-    fn encode_raw<B>(&self, buf: &mut B) 
+    fn encode_raw<B>(&self, buf: &mut B)
     where
         B: prost::bytes::BufMut,
     {
         // Encode key (field 1)
         prost::encoding::string::encode(1, &self.key, buf);
-        
+
         // Encode value (field 2)
         prost::encoding::string::encode(2, &self.value, buf);
     }
-    
+
     fn merge_field<B>(
         &mut self,
         tag: u32,
@@ -167,12 +169,12 @@ impl ProstMessage for MetadataEntry {
             _ => prost::encoding::skip_field(wire_type, tag, buf, ctx),
         }
     }
-    
+
     fn encoded_len(&self) -> usize {
-        prost::encoding::string::encoded_len(1, &self.key) +
-        prost::encoding::string::encoded_len(2, &self.value)
+        prost::encoding::string::encoded_len(1, &self.key)
+            + prost::encoding::string::encoded_len(2, &self.value)
     }
-    
+
     fn clear(&mut self) {
         self.key.clear();
         self.value.clear();
@@ -231,16 +233,17 @@ impl MessageCodec for ProtobufCodec {
     fn encode(&self, message: &Message) -> Result<Vec<u8>, Self::Error> {
         let proto = self.message_to_proto(message);
         let mut buf = Vec::new();
-        
-        proto.encode(&mut buf)
+
+        proto
+            .encode(&mut buf)
             .map_err(|e| ProtobufError::Encode(e.to_string()))?;
         Ok(buf)
     }
 
     fn decode(&self, bytes: &[u8]) -> Result<Message, Self::Error> {
-        let proto = ProtoMessage::decode(bytes)
-            .map_err(|e| ProtobufError::Decode(e.to_string()))?;
-            
+        let proto =
+            ProtoMessage::decode(bytes).map_err(|e| ProtobufError::Decode(e.to_string()))?;
+
         Ok(self.proto_to_message(proto))
     }
 }
@@ -248,7 +251,7 @@ impl MessageCodec for ProtobufCodec {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_protobuf_codec_roundtrip() {
         // Create a message with metadata
@@ -256,17 +259,17 @@ mod tests {
         original = original
             .with_metadata("content-type", "text/plain")
             .with_metadata("priority", "high");
-            
+
         // Create codec
         let codec = ProtobufCodec::new();
-        
+
         // Encode and decode
         let encoded = codec.encode(&original).unwrap();
         let decoded = codec.decode(&encoded).unwrap();
-        
+
         // Verify
         assert_eq!(original.uuid, decoded.uuid);
         assert_eq!(original.payload, decoded.payload);
         assert_eq!(original.metadata, decoded.metadata);
     }
-} 
+}

--- a/kincir/src/protobuf.rs
+++ b/kincir/src/protobuf.rs
@@ -54,8 +54,14 @@ pub trait MessageCodec {
 /// Uses Protocol Buffers for message serialization and deserialization.
 pub struct ProtobufCodec;
 
+impl Default for ProtobufCodec {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// The Protocol Buffer representation of a Message.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, Default)]
 pub struct ProtoMessage {
     /// Unique identifier for the message
     pub uuid: String,
@@ -66,7 +72,7 @@ pub struct ProtoMessage {
 }
 
 /// A single key-value entry in the message metadata.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, Default)]
 pub struct MetadataEntry {
     /// The key of the metadata entry
     pub key: String,
@@ -131,16 +137,6 @@ impl ProstMessage for ProtoMessage {
     }
 }
 
-impl Default for ProtoMessage {
-    fn default() -> Self {
-        Self {
-            uuid: String::new(),
-            payload: Vec::new(),
-            metadata: Vec::new(),
-        }
-    }
-}
-
 impl ProstMessage for MetadataEntry {
     fn encode_raw<B>(&self, buf: &mut B)
     where
@@ -178,15 +174,6 @@ impl ProstMessage for MetadataEntry {
     fn clear(&mut self) {
         self.key.clear();
         self.value.clear();
-    }
-}
-
-impl Default for MetadataEntry {
-    fn default() -> Self {
-        Self {
-            key: String::new(),
-            value: String::new(),
-        }
     }
 }
 

--- a/kincir/src/rabbitmq.rs
+++ b/kincir/src/rabbitmq.rs
@@ -8,7 +8,7 @@
 //!
 //! ```rust,no_run
 //! use kincir::rabbitmq::{RabbitMQPublisher, RabbitMQSubscriber};
-//! use kincir::router::{Router, StdLogger};
+//! use kincir::logging::StdLogger;
 //! use std::sync::Arc;
 //!
 //! #[tokio::main]
@@ -24,6 +24,8 @@
 //! ```
 
 use crate::Message;
+#[cfg(feature = "logging")]
+use crate::logging::Logger;
 use async_trait::async_trait;
 use futures::StreamExt;
 use lapin::options::{BasicConsumeOptions, BasicPublishOptions, QueueDeclareOptions};
@@ -32,7 +34,7 @@ use lapin::{BasicProperties, Connection, ConnectionProperties};
 use serde_json;
 use std::sync::Arc;
 use thiserror::Error;
-// Remove unused import
+
 #[derive(Error, Debug)]
 pub enum RabbitMQError {
     /// Error when interacting with RabbitMQ
@@ -48,6 +50,8 @@ pub enum RabbitMQError {
 /// Uses the lapin library for RabbitMQ communication.
 pub struct RabbitMQPublisher {
     connection: Connection,
+    #[cfg(feature = "logging")]
+    logger: Arc<dyn Logger>,
 }
 
 impl RabbitMQPublisher {
@@ -56,6 +60,7 @@ impl RabbitMQPublisher {
     /// # Arguments
     ///
     /// * `uri` - The RabbitMQ connection URI (e.g., "amqp://localhost:5672")
+    #[cfg(not(feature = "logging"))]
     pub async fn new(uri: &str) -> Result<Self, RabbitMQError> {
         let connection = Connection::connect(uri, ConnectionProperties::default())
             .await
@@ -63,8 +68,85 @@ impl RabbitMQPublisher {
 
         Ok(Self { connection })
     }
+
+    /// Creates a new RabbitMQPublisher instance with logging.
+    ///
+    /// # Arguments
+    ///
+    /// * `uri` - The RabbitMQ connection URI (e.g., "amqp://localhost:5672")
+    /// * `logger` - The logger implementation to use
+    #[cfg(feature = "logging")]
+    pub async fn new(uri: &str) -> Result<Self, RabbitMQError> {
+        let connection = Connection::connect(uri, ConnectionProperties::default())
+            .await
+            .map_err(RabbitMQError::RabbitMQ)?;
+        
+        // Create a default NoOpLogger
+        let logger = Arc::new(crate::logging::NoOpLogger::new());
+
+        Ok(Self { connection, logger })
+    }
+
+    /// Sets a logger for the publisher (only available with the "logging" feature).
+    #[cfg(feature = "logging")]
+    pub fn with_logger(mut self, logger: Arc<dyn Logger>) -> Self {
+        self.logger = logger;
+        self
+    }
 }
 
+#[cfg(feature = "logging")]
+#[async_trait]
+impl super::Publisher for RabbitMQPublisher {
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+
+    async fn publish(&self, topic: &str, messages: Vec<Message>) -> Result<(), Self::Error> {
+        self.logger
+            .info(&format!("Publishing {} messages to {}", messages.len(), topic))
+            .await;
+
+        let channel = self.connection.create_channel().await.map_err(|e| {
+            Box::new(RabbitMQError::RabbitMQ(e)) as Box<dyn std::error::Error + Send + Sync>
+        })?;
+
+        channel
+            .queue_declare(topic, QueueDeclareOptions::default(), FieldTable::default())
+            .await
+            .map_err(|e| {
+                Box::new(RabbitMQError::RabbitMQ(e)) as Box<dyn std::error::Error + Send + Sync>
+            })?;
+
+        for message in messages {
+            let payload = serde_json::to_vec(&message).map_err(|e| {
+                Box::new(RabbitMQError::Serialization(e))
+                    as Box<dyn std::error::Error + Send + Sync>
+            })?;
+            let confirm = channel
+                .basic_publish(
+                    "",
+                    topic,
+                    BasicPublishOptions::default(),
+                    &payload,
+                    BasicProperties::default(),
+                )
+                .await
+                .map_err(|e| {
+                    Box::new(RabbitMQError::RabbitMQ(e)) as Box<dyn std::error::Error + Send + Sync>
+                })?;
+            let _ = confirm.await.map_err(|e| {
+                Box::new(RabbitMQError::RabbitMQ(e)) as Box<dyn std::error::Error + Send + Sync>
+            })?;
+            
+            self.logger
+                .info(&format!("Published message {} to {}", message.uuid, topic))
+                .await;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(not(feature = "logging"))]
 #[async_trait]
 impl super::Publisher for RabbitMQPublisher {
     type Error = Box<dyn std::error::Error + Send + Sync>;
@@ -114,6 +196,8 @@ pub struct RabbitMQSubscriber {
     connection: Connection,
     topic: Arc<tokio::sync::Mutex<Option<String>>>,
     consumer: Arc<tokio::sync::Mutex<Option<lapin::Consumer>>>,
+    #[cfg(feature = "logging")]
+    logger: Arc<dyn Logger>,
 }
 
 impl RabbitMQSubscriber {
@@ -122,6 +206,7 @@ impl RabbitMQSubscriber {
     /// # Arguments
     ///
     /// * `uri` - The RabbitMQ connection URI (e.g., "amqp://localhost:5672")
+    #[cfg(not(feature = "logging"))]
     pub async fn new(uri: &str) -> Result<Self, RabbitMQError> {
         let connection = Connection::connect(uri, ConnectionProperties::default())
             .await
@@ -133,8 +218,131 @@ impl RabbitMQSubscriber {
             consumer: Arc::new(tokio::sync::Mutex::new(None)),
         })
     }
+
+    /// Creates a new RabbitMQSubscriber instance with logging.
+    ///
+    /// # Arguments
+    ///
+    /// * `uri` - The RabbitMQ connection URI (e.g., "amqp://localhost:5672")
+    #[cfg(feature = "logging")]
+    pub async fn new(uri: &str) -> Result<Self, RabbitMQError> {
+        let connection = Connection::connect(uri, ConnectionProperties::default())
+            .await
+            .map_err(RabbitMQError::RabbitMQ)?;
+            
+        // Create a default NoOpLogger
+        let logger = Arc::new(crate::logging::NoOpLogger::new());
+
+        Ok(Self {
+            connection,
+            topic: Arc::new(tokio::sync::Mutex::new(None)),
+            consumer: Arc::new(tokio::sync::Mutex::new(None)),
+            logger,
+        })
+    }
+
+    /// Sets a logger for the subscriber (only available with the "logging" feature).
+    #[cfg(feature = "logging")]
+    pub fn with_logger(mut self, logger: Arc<dyn Logger>) -> Self {
+        self.logger = logger;
+        self
+    }
 }
 
+#[cfg(feature = "logging")]
+#[async_trait]
+impl super::Subscriber for RabbitMQSubscriber {
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+
+    async fn subscribe(&self, topic: &str) -> Result<(), Self::Error> {
+        self.logger
+            .info(&format!("Subscribing to topic {}", topic))
+            .await;
+            
+        let channel = self.connection.create_channel().await.map_err(|e| {
+            Box::new(RabbitMQError::RabbitMQ(e)) as Box<dyn std::error::Error + Send + Sync>
+        })?;
+
+        channel
+            .queue_declare(topic, QueueDeclareOptions::default(), FieldTable::default())
+            .await
+            .map_err(|e| {
+                Box::new(RabbitMQError::RabbitMQ(e)) as Box<dyn std::error::Error + Send + Sync>
+            })?;
+
+        let mut topic_guard = self.topic.lock().await;
+        *topic_guard = Some(topic.to_string());
+
+        // Create a consumer for the topic
+        let mut consumer_guard = self.consumer.lock().await;
+        *consumer_guard = Some(
+            channel
+                .basic_consume(
+                    topic,
+                    &format!("consumer-{}", uuid::Uuid::new_v4()),
+                    BasicConsumeOptions::default(),
+                    FieldTable::default(),
+                )
+                .await
+                .map_err(|e| {
+                    Box::new(RabbitMQError::RabbitMQ(e)) as Box<dyn std::error::Error + Send + Sync>
+                })?,
+        );
+        
+        self.logger
+            .info(&format!("Successfully subscribed to topic {}", topic))
+            .await;
+
+        Ok(())
+    }
+
+    async fn receive(&self) -> Result<Message, Self::Error> {
+        self.logger.info("Waiting to receive message").await;
+        
+        let topic_guard = self.topic.lock().await;
+        let _topic = topic_guard.as_ref().ok_or_else(|| {
+            Box::new(RabbitMQError::RabbitMQ(lapin::Error::InvalidChannelState(
+                lapin::ChannelState::Error,
+            ))) as Box<dyn std::error::Error + Send + Sync>
+        })?;
+
+        let mut consumer_guard = self.consumer.lock().await;
+        let consumer = consumer_guard.as_mut().ok_or_else(|| {
+            Box::new(RabbitMQError::RabbitMQ(lapin::Error::InvalidChannelState(
+                lapin::ChannelState::Error,
+            ))) as Box<dyn std::error::Error + Send + Sync>
+        })?;
+
+        if let Some(delivery) = consumer.next().await {
+            let delivery = delivery.map_err(|e| {
+                Box::new(RabbitMQError::RabbitMQ(e)) as Box<dyn std::error::Error + Send + Sync>
+            })?;
+            let message: Message = serde_json::from_slice(&delivery.data).map_err(|e| {
+                Box::new(RabbitMQError::Serialization(e))
+                    as Box<dyn std::error::Error + Send + Sync>
+            })?;
+            delivery.ack(Default::default()).await.map_err(|e| {
+                Box::new(RabbitMQError::RabbitMQ(e)) as Box<dyn std::error::Error + Send + Sync>
+            })?;
+            
+            self.logger
+                .info(&format!("Received message {}", message.uuid))
+                .await;
+                
+            Ok(message)
+        } else {
+            self.logger.error("Consumer stream ended unexpectedly").await;
+            
+            Err(
+                Box::new(RabbitMQError::RabbitMQ(lapin::Error::InvalidChannelState(
+                    lapin::ChannelState::Error,
+                ))) as Box<dyn std::error::Error + Send + Sync>,
+            )
+        }
+    }
+}
+
+#[cfg(not(feature = "logging"))]
 #[async_trait]
 impl super::Subscriber for RabbitMQSubscriber {
     type Error = Box<dyn std::error::Error + Send + Sync>;

--- a/kincir/src/rabbitmq.rs
+++ b/kincir/src/rabbitmq.rs
@@ -21,7 +21,6 @@
 //!
 //!     Ok(())
 //! }
-//! ```
 
 #[cfg(feature = "logging")]
 use crate::logging::Logger;

--- a/kincir/src/router.rs
+++ b/kincir/src/router.rs
@@ -157,9 +157,6 @@ pub type HandlerFunc = Arc<
 ///     router.run().await
 /// # }
 /// # }
-/// ```
-
-#[cfg(feature = "logging")]
 pub struct Router {
     logger: Arc<dyn Logger>,
     consume_topic: String,

--- a/kincir/src/router.rs
+++ b/kincir/src/router.rs
@@ -70,7 +70,6 @@
 //!     router.run().await
 //! # }
 //! # }
-//! ```
 
 use crate::Message;
 use std::error::Error;
@@ -157,6 +156,7 @@ pub type HandlerFunc = Arc<
 ///     router.run().await
 /// # }
 /// # }
+#[cfg(feature = "logging")]
 pub struct Router {
     logger: Arc<dyn Logger>,
     consume_topic: String,

--- a/kincir/src/router.rs
+++ b/kincir/src/router.rs
@@ -1,26 +1,31 @@
-//! Message routing and logging functionality for the Kincir messaging system.
+//! Message routing functionality for the Kincir messaging system.
 //!
 //! This module provides the core routing capabilities that enable message processing
 //! and forwarding between different topics/queues. It includes:
 //!
 //! - A flexible `Router` implementation for message handling and routing
-//! - A `Logger` trait for customizable logging
-//! - A standard logger implementation (`StdLogger`)
 //! - Type definitions for message handler functions
+//! 
+//! When the "logging" feature is enabled, it also includes integration with the
+//! `Logger` trait from the logging module.
 //!
 //! # Example
 //!
 //! ```rust,no_run
-//! use kincir::router::{Router, Logger, StdLogger};
+//! use kincir::router::Router;
 //! use kincir::Message;
 //! use kincir::rabbitmq::{RabbitMQPublisher, RabbitMQSubscriber};
 //! use std::sync::Arc;
 //! use std::pin::Pin;
 //! use std::future::Future;
 //!
-//! #[tokio::main]
-//! async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-//!     let logger = Arc::new(StdLogger::new(true, true));
+//! # async fn example() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+//! # // The following part will only be compiled when the "logging" feature is enabled
+//! # #[cfg(feature = "logging")]
+//! # {
+//! # use kincir::logging::{Logger, StdLogger};
+//! # let logger = Arc::new(StdLogger::new(true, true));
+//! # }
 //!     let handler = Arc::new(|msg: Message| -> Pin<Box<dyn Future<Output = Result<Vec<Message>, Box<dyn std::error::Error + Send + Sync>>> + Send>> {
 //!         Box::pin(async move {
 //!             // Process message here
@@ -32,6 +37,12 @@
 //!     let publisher = Arc::new(RabbitMQPublisher::new("amqp://localhost:5672").await?);
 //!     let subscriber = Arc::new(RabbitMQSubscriber::new("amqp://localhost:5672").await?);
 //!
+//! # // Create the router differently based on feature flags
+//! # #[cfg(feature = "logging")]
+//! # {
+//!     // With the "logging" feature enabled, include a logger
+//! # use kincir::logging::Logger;
+//! # let logger = Arc::new(kincir::logging::StdLogger::new(true, true));
 //!     let router = Router::new(
 //!         logger,
 //!         "input-queue".to_string(),
@@ -40,66 +51,31 @@
 //!         publisher,
 //!         handler,
 //!     );
+//! # }
+//! # #[cfg(not(feature = "logging"))]
+//! # {
+//!     // Without the "logging" feature, don't include a logger
+//!     let router = Router::new(
+//!         "input-queue".to_string(),
+//!         "output-queue".to_string(),
+//!         subscriber,
+//!         publisher,
+//!         handler,
+//!     );
+//! # }
 //!
 //!     router.run().await
-//! }
+//! # }
 //! ```
 
 use crate::Message;
-use async_trait::async_trait;
 use std::error::Error;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-/// Defines the interface for logging operations in the router.
-#[async_trait]
-pub trait Logger: Send + Sync {
-    /// Logs an informational message.
-    async fn info(&self, msg: &str);
-    /// Logs an error message.
-    async fn error(&self, msg: &str);
-}
-
-/// A standard implementation of the Logger trait that writes to stdout/stderr.
-///
-/// This logger provides basic logging capabilities with configurable output levels.
-pub struct StdLogger {
-    /// Whether to show informational messages
-    show_info: bool,
-    /// Whether to show error messages
-    show_error: bool,
-}
-
-impl StdLogger {
-    /// Creates a new StdLogger with configurable output levels.
-    ///
-    /// # Arguments
-    ///
-    /// * `show_info` - Whether to display informational messages
-    /// * `show_error` - Whether to display error messages
-    pub fn new(show_info: bool, show_error: bool) -> Self {
-        Self {
-            show_info,
-            show_error,
-        }
-    }
-}
-
-#[async_trait]
-impl Logger for StdLogger {
-    async fn info(&self, msg: &str) {
-        if self.show_info {
-            println!("[INFO] {}", msg);
-        }
-    }
-
-    async fn error(&self, msg: &str) {
-        if self.show_error {
-            eprintln!("[ERROR] {}", msg);
-        }
-    }
-}
+#[cfg(feature = "logging")]
+use crate::logging::Logger;
 
 /// Type alias for message handler functions.
 ///
@@ -120,7 +96,8 @@ pub type HandlerFunc = Arc<
 /// - Subscribing to input topics
 /// - Processing messages using the provided handler
 /// - Publishing processed messages to output topics
-/// - Logging operations and errors
+#[cfg_attr(feature = "logging", doc = "- Logging operations and errors")]
+#[cfg(feature = "logging")]
 pub struct Router {
     logger: Arc<dyn Logger>,
     consume_topic: String,
@@ -130,8 +107,18 @@ pub struct Router {
     handler: HandlerFunc,
 }
 
+#[cfg(not(feature = "logging"))]
+pub struct Router {
+    consume_topic: String,
+    publish_topic: String,
+    subscriber: Arc<dyn crate::Subscriber<Error = Box<dyn Error + Send + Sync>>>,
+    publisher: Arc<dyn crate::Publisher<Error = Box<dyn Error + Send + Sync>>>,
+    handler: HandlerFunc,
+}
+
+#[cfg(feature = "logging")]
 impl Router {
-    /// Creates a new Router instance.
+    /// Creates a new Router instance with logging.
     ///
     /// # Arguments
     ///
@@ -180,6 +167,9 @@ impl Router {
                     match (self.handler)(msg).await {
                         Ok(processed_msgs) => {
                             if !processed_msgs.is_empty() {
+                                self.logger
+                                    .info(&format!("Publishing {} messages", processed_msgs.len()))
+                                    .await;
                                 self.publisher
                                     .publish(&self.publish_topic, processed_msgs)
                                     .await?
@@ -196,6 +186,67 @@ impl Router {
                     self.logger
                         .error(&format!("Error receiving message: {}", e))
                         .await;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "logging"))]
+impl Router {
+    /// Creates a new Router instance without logging.
+    ///
+    /// # Arguments
+    ///
+    /// * `consume_topic` - The topic/queue to consume messages from
+    /// * `publish_topic` - The topic/queue to publish processed messages to
+    /// * `subscriber` - The subscriber implementation
+    /// * `publisher` - The publisher implementation
+    /// * `handler` - The message processing function
+    pub fn new(
+        consume_topic: String,
+        publish_topic: String,
+        subscriber: Arc<dyn crate::Subscriber<Error = Box<dyn Error + Send + Sync>>>,
+        publisher: Arc<dyn crate::Publisher<Error = Box<dyn Error + Send + Sync>>>,
+        handler: HandlerFunc,
+    ) -> Self {
+        Self {
+            consume_topic,
+            publish_topic,
+            subscriber,
+            publisher,
+            handler,
+        }
+    }
+
+    /// Starts the router's message processing loop.
+    ///
+    /// This method will:
+    /// 1. Subscribe to the input topic
+    /// 2. Continuously receive messages
+    /// 3. Process messages using the handler
+    /// 4. Publish processed messages to the output topic
+    pub async fn run(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+        self.subscriber.subscribe(&self.consume_topic).await?;
+
+        loop {
+            match self.subscriber.receive().await {
+                Ok(msg) => {
+                    match (self.handler)(msg).await {
+                        Ok(processed_msgs) => {
+                            if !processed_msgs.is_empty() {
+                                self.publisher
+                                    .publish(&self.publish_topic, processed_msgs)
+                                    .await?
+                            }
+                        }
+                        Err(_) => {
+                            // Error handling without logging
+                        }
+                    }
+                }
+                Err(_) => {
+                    // Error handling without logging
                 }
             }
         }

--- a/kincir/src/router.rs
+++ b/kincir/src/router.rs
@@ -5,7 +5,7 @@
 //!
 //! - A flexible `Router` implementation for message handling and routing
 //! - Type definitions for message handler functions
-//! 
+//!
 //! When the "logging" feature is enabled, it also includes integration with the
 //! `Logger` trait from the logging module.
 //!

--- a/rustdoc.css
+++ b/rustdoc.css
@@ -1,0 +1,124 @@
+/* Custom styles for Kincir documentation */
+
+:root {
+    --primary-color: #4169e1;  /* Royal Blue */
+    --secondary-color: #1e3a8a;  /* Darker Blue */
+    --accent-color: #ffa500;  /* Orange - for windmill theme */
+}
+
+/* Adjust link colors and styling */
+.content a:link, .content a:visited {
+    color: var(--primary-color);
+}
+
+.content a:hover {
+    color: var(--accent-color);
+}
+
+a {
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+/* Style the main heading */
+h1.fqn {
+    border-bottom: 1px solid var(--accent-color);
+    padding-bottom: 10px;
+}
+
+/* Style the sidebar sections */
+#sidebar .section {
+    border-left: 2px solid var(--primary-color);
+    padding-left: 10px;
+    margin-bottom: 20px;
+}
+
+#sidebar .section h3 {
+    color: var(--secondary-color);
+    font-weight: bold;
+}
+
+nav.sidebar {
+  background-color: #f7f7f7;
+}
+
+/* Style the main content area */
+main {
+  padding: 20px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+/* Add a small windmill icon before important items */
+.item-name::before {
+    content: "🔄 ";
+    opacity: 0.7;
+}
+
+/* Remove the icon from some elements */
+.impl-items .item-name::before,
+.methods .item-name::before {
+    content: "";
+}
+
+/* Style the code blocks */
+pre.rust {
+    padding: 15px;
+    border-radius: 5px;
+    background-color: #f5f5f5;
+    border-left: 3px solid var(--accent-color);
+}
+
+/* Style the main documentation section */
+.docblock {
+    padding: 15px;
+    border-radius: 5px;
+    background-color: rgba(65, 105, 225, 0.05);
+}
+
+/* Style the top navbar */
+nav.sub {
+    background-color: rgba(65, 105, 225, 0.1);
+    border-radius: 5px;
+    padding: 5px;
+}
+
+/* Custom styling for the navigation header */
+.nav-container {
+  padding: 10px 0;
+}
+
+/* Signature blocks */
+.signature {
+    border-left: 3px solid var(--primary-color);
+    background-color: rgba(65, 105, 225, 0.05);
+}
+
+/* Improve method documentation */
+.method-toggle {
+  border-radius: 4px;
+  margin-bottom: 15px;
+}
+
+/* Better styling for important documentation notes */
+.important-note {
+  background-color: #fff8dc;
+  border-left: 4px solid #ffd700;
+  padding: 10px 15px;
+  margin: 15px 0;
+  border-radius: 0 4px 4px 0;
+}
+
+/* Improve the search box */
+.search-input {
+  border-radius: 4px;
+  padding: 8px 12px;
+}
+
+/* Better styling for type definitions */
+.impl-items .method {
+  margin-bottom: 20px;
+} 


### PR DESCRIPTION
# Feature Flags & Documentation Enhancements

## Overview
This PR introduces a comprehensive feature flag system for Kincir, allowing users to customize their builds with only the features they need. The PR also includes significant documentation improvements, stylistic enhancements, and several bug fixes.

## Key Changes

### Feature Flags
- Added optional logging via the `logging` feature flag (enabled by default)
- Added Protocol Buffers support with the `protobuf` feature flag
- Updated code structure to properly handle conditional compilation
- Ensured API consistency across all feature combinations

### Documentation Improvements
- Enhanced README with feature flag usage examples and instructions
- Added custom CSS styling for documentation with a windmill-themed design
- Updated GitHub Actions workflow to include the custom CSS in documentation builds
- Documented Protocol Buffers encoding/decoding capabilities
- Added detailed code examples for each feature flag configuration
- Updated CHANGELOG.md for the 0.1.6 release

### Bug Fixes & Code Quality
- Fixed Clippy warnings in logging.rs, protobuf.rs, and protobuf example
- Improved code formatting throughout the codebase
- Fixed examples to properly demonstrate feature flag usage
- Bumped version to 0.1.6 to reflect the new Protocol Buffers capabilities

## Testing
All feature flag combinations have been tested to ensure no regressions:
- Default features (logging enabled)
- No default features
- With only Protocol Buffers
- With both logging and Protocol Buffers

## Documentation Link
The styled documentation can be previewed at: https://rezacute.github.io/kincir/

## Roadmap Impact
This PR completes a significant portion of our roadmap to v1.0, particularly adding the groundwork for modular features that will be crucial for our upcoming middleware and backend expansions.