### PR TITLE
Update Rust to 1.87.0 and fix CI issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.76-slim as builder
+FROM rust:1.87.0-slim as builder
 
 WORKDIR /usr/src/kincir
 

--- a/kincir/src/lib.rs
+++ b/kincir/src/lib.rs
@@ -42,12 +42,13 @@
 //! # {
 //! // With logging (when "logging" feature is enabled)
 //! use kincir::logging::{Logger, StdLogger};
+//! use tokio::sync::Mutex;
 //! let logger = Arc::new(StdLogger::new(true, true));
 //! let router = Router::new(
 //!     logger,
 //!     "input-queue".to_string(),
 //!     "output-queue".to_string(),
-//!     subscriber.clone(),
+//!     Arc::new(Mutex::new(RabbitMQSubscriber::new("amqp://localhost:5672").await?)),
 //!     publisher.clone(),
 //!     handler.clone(),
 //! );
@@ -57,10 +58,12 @@
 //! # #[cfg(not(feature = "logging"))]
 //! # {
 //! // Without logging (when "logging" feature is disabled)
+//! use tokio::sync::Mutex;
+//! let subscriber_instance = RabbitMQSubscriber::new("amqp://localhost:5672").await?;
 //! let router = Router::new(
 //!     "input-queue".to_string(),
 //!     "output-queue".to_string(),
-//!     subscriber,
+//!     Arc::new(Mutex::new(subscriber_instance)),
 //!     publisher,
 //!     handler,
 //! );

--- a/kincir/src/rabbitmq.rs
+++ b/kincir/src/rabbitmq.rs
@@ -210,7 +210,6 @@ impl RabbitMQSubscriber {
     ///
     /// * `uri` - The RabbitMQ connection URI (e.g., "amqp://localhost:5672")
     #[cfg(not(feature = "logging"))]
-
     pub async fn new(uri: &str) -> Result<Self, RabbitMQError> {
         let connection = Connection::connect(uri, ConnectionProperties::default())
             .await
@@ -220,29 +219,6 @@ impl RabbitMQSubscriber {
             connection,
             topic: Arc::new(tokio::sync::Mutex::new(None)),
             consumer: Arc::new(tokio::sync::Mutex::new(None)),
-        })
-    }
-
-    /// Creates a new RabbitMQSubscriber instance with logging.
-    ///
-    /// # Arguments
-    ///
-    /// * `uri` - The RabbitMQ connection URI (e.g., "amqp://localhost:5672")
-    #[cfg(feature = "logging")]
-
-    pub async fn new(uri: &str) -> Result<Self, RabbitMQError> {
-        let connection = Connection::connect(uri, ConnectionProperties::default())
-            .await
-            .map_err(RabbitMQError::RabbitMQ)?;
-
-        // Create a default NoOpLogger
-        let logger = Arc::new(crate::logging::NoOpLogger::new());
-
-        Ok(Self {
-            connection,
-            topic: Arc::new(tokio::sync::Mutex::new(None)),
-            consumer: Arc::new(tokio::sync::Mutex::new(None)),
-            logger,
         })
     }
 

--- a/kincir/src/router.rs
+++ b/kincir/src/router.rs
@@ -35,19 +35,20 @@
 //!
 //!     // Set up router with RabbitMQ backend
 //!     let publisher = Arc::new(RabbitMQPublisher::new("amqp://localhost:5672").await?);
-//!     let subscriber = Arc::new(RabbitMQSubscriber::new("amqp://localhost:5672").await?);
+//!     let subscriber_instance = RabbitMQSubscriber::new("amqp://localhost:5672").await?;
 //!
 //! # // Create the router differently based on feature flags
 //! # #[cfg(feature = "logging")]
 //! # {
 //!     // With the "logging" feature enabled, include a logger
 //! # use kincir::logging::Logger;
+//! # use tokio::sync::Mutex;
 //! # let logger = Arc::new(kincir::logging::StdLogger::new(true, true));
 //!     let router = Router::new(
 //!         logger,
 //!         "input-queue".to_string(),
 //!         "output-queue".to_string(),
-//!         subscriber,
+//!         Arc::new(Mutex::new(subscriber_instance)),
 //!         publisher,
 //!         handler,
 //!     );
@@ -58,10 +59,11 @@
 //! # #[cfg(not(feature = "logging"))]
 //! # {
 //!     // Without the "logging" feature, don't include a logger
+//! # use tokio::sync::Mutex;
 //!     let router = Router::new(
 //!         "input-queue".to_string(),
 //!         "output-queue".to_string(),
-//!         subscriber,
+//!         Arc::new(Mutex::new(subscriber_instance)),
 //!         publisher,
 //!         handler,
 //!     );
@@ -121,19 +123,20 @@ pub type HandlerFunc = Arc<
 ///
 ///     // Set up router with RabbitMQ backend
 ///     let publisher = Arc::new(RabbitMQPublisher::new("amqp://localhost:5672").await?);
-///     let subscriber = Arc::new(RabbitMQSubscriber::new("amqp://localhost:5672").await?);
+///     let subscriber_instance = RabbitMQSubscriber::new("amqp://localhost:5672").await?;
 ///
 /// # // Create the router differently based on feature flags
 /// # #[cfg(feature = "logging")]
 /// # {
 ///     // With the "logging" feature enabled, include a logger
 /// # use kincir::logging::Logger;
+/// # use tokio::sync::Mutex;
 /// # let logger = Arc::new(kincir::logging::StdLogger::new(true, true));
 ///     let router = Router::new(
 ///         logger,
 ///         "input-queue".to_string(),
 ///         "output-queue".to_string(),
-///         subscriber,
+///         Arc::new(Mutex::new(subscriber_instance)),
 ///         publisher,
 ///         handler,
 ///     );
@@ -144,10 +147,11 @@ pub type HandlerFunc = Arc<
 /// # #[cfg(not(feature = "logging"))]
 /// # {
 ///     // Without the "logging" feature, don't include a logger
+/// # use tokio::sync::Mutex;
 ///     let router = Router::new(
 ///         "input-queue".to_string(),
 ///         "output-queue".to_string(),
-///         subscriber,
+///         Arc::new(Mutex::new(subscriber_instance)),
 ///         publisher,
 ///         handler,
 ///     );


### PR DESCRIPTION
- I've updated the Rust version in the Dockerfile to 1.87.0-slim.
- I've updated the Rust version in the development environment to the latest stable (1.87.0).
- I've fixed various issues identified by `cargo check`, `cargo test`, and `cargo clippy` after the Rust version update.
  - I installed the missing `cmake` dependency.
  - I removed a duplicate function definition in `kincir/src/rabbitmq.rs`.
  - I corrected doctests in `kincir/src/lib.rs` and `kincir/src/router.rs` to resolve type mismatch errors.
  - I fixed a clippy warning related to an empty line after an outer attribute in `kincir/src/rabbitmq.rs`.
- I've ensured `scripts/generate_docs.sh` runs successfully with the updated Rust version.