### PR TITLE
Resolve clippy lints across test and benchmark code

### DIFF
--- a/kincir/benches/acknowledgment_performance.rs
+++ b/kincir/benches/acknowledgment_performance.rs
@@ -10,7 +10,7 @@ fn create_ack_test_messages(count: usize, size: usize) -> Vec<Message> {
     (0..count)
         .map(|i| {
             Message::new(payload.clone())
-                .with_metadata("ack_id", &i.to_string())
+                .with_metadata("ack_id", i.to_string())
                 .with_metadata("benchmark", "acknowledgment")
         })
         .collect()

--- a/kincir/benches/backend_comparison.rs
+++ b/kincir/benches/backend_comparison.rs
@@ -50,10 +50,10 @@ fn create_test_messages(count: usize, size: usize) -> Vec<Message> {
         .map(|i| {
             let payload = vec![0u8; size];
             let mut msg = Message::new(payload);
-            msg = msg.with_metadata("benchmark_id", &i.to_string());
+            msg = msg.with_metadata("benchmark_id", i.to_string());
             msg = msg.with_metadata(
                 "timestamp",
-                &std::time::SystemTime::now()
+                std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap()
                     .as_nanos()

--- a/kincir/benches/concurrent_operations.rs
+++ b/kincir/benches/concurrent_operations.rs
@@ -8,7 +8,7 @@ fn create_concurrent_messages(count: usize, prefix: &str) -> Vec<Message> {
     (0..count)
         .map(|i| {
             Message::new(format!("{} message {}", prefix, i).into_bytes())
-                .with_metadata("message_id", &i.to_string())
+                .with_metadata("message_id", i.to_string())
                 .with_metadata("benchmark", "concurrent")
         })
         .collect()

--- a/kincir/benches/memory_broker.rs
+++ b/kincir/benches/memory_broker.rs
@@ -9,7 +9,7 @@ fn create_test_messages(count: usize, size: usize) -> Vec<Message> {
     (0..count)
         .map(|i| {
             Message::new(payload.clone())
-                .with_metadata("message_id", &i.to_string())
+                .with_metadata("message_id", i.to_string())
                 .with_metadata("benchmark", "memory_broker")
         })
         .collect()
@@ -108,7 +108,7 @@ fn bench_concurrent_operations(c: &mut Criterion) {
 
                         // Create publishers
                         let mut publisher_handles = Vec::new();
-                        for pub_id in 0..pub_count {
+                        for _pub_id in 0..pub_count {
                             let broker_clone = broker.clone();
                             let handle = tokio::spawn(async move {
                                 let publisher = InMemoryPublisher::new(broker_clone);

--- a/kincir/benches/router_performance.rs
+++ b/kincir/benches/router_performance.rs
@@ -20,7 +20,7 @@ fn create_router_messages(count: usize, size: usize) -> Vec<Message> {
     (0..count)
         .map(|i| {
             Message::new(payload.clone())
-                .with_metadata("router_id", &i.to_string())
+                .with_metadata("router_id", i.to_string())
                 .with_metadata("benchmark", "router")
         })
         .collect()
@@ -37,7 +37,7 @@ fn create_processing_handler() -> HandlerFunc {
         Box::pin(async move {
             let processed = msg.with_metadata("processed", "true").with_metadata(
                 "processed_at",
-                &std::time::SystemTime::now()
+                std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap()
                     .as_millis()

--- a/kincir/src/backend/tests.rs
+++ b/kincir/src/backend/tests.rs
@@ -1,6 +1,7 @@
 //! Unit tests for the backend module
 
 #[cfg(test)]
+#[allow(clippy::module_inception)]
 mod tests {
     use crate::backend::{BackendError, BackendType};
 

--- a/kincir/src/kafka/tests.rs
+++ b/kincir/src/kafka/tests.rs
@@ -606,7 +606,7 @@ mod kafka_performance_unit_tests {
                     "test-topic".to_string(),
                     SystemTime::now(),
                     1,
-                    (i % 10) as i32, // 10 partitions
+                    i % 10, // 10 partitions
                     i as i64,
                 )
             })
@@ -636,7 +636,7 @@ mod kafka_performance_unit_tests {
         assert_eq!(partition_offsets.len(), 10); // 10 partitions
         for i in 0..10 {
             let expected_max = ((999 / 10) * 10 + i) as i64; // Highest offset for partition i
-            assert!(partition_offsets.get(&(i as i32)).unwrap() >= &expected_max);
+            assert!(partition_offsets.get(&{ i }).unwrap() >= &expected_max);
         }
     }
 }

--- a/kincir/src/memory/ack_fixed.rs
+++ b/kincir/src/memory/ack_fixed.rs
@@ -362,8 +362,8 @@ mod tests {
         for i in 0..3 {
             let (received, handle) = timeout(Duration::from_secs(2), subscriber.receive_with_ack())
                 .await
-                .expect(&format!("Timeout waiting for message {}", i + 1))
-                .expect(&format!("Failed to receive message {}", i + 1));
+                .unwrap_or_else(|_| panic!("Timeout waiting for message {}", i + 1))
+                .unwrap_or_else(|_| panic!("Failed to receive message {}", i + 1));
 
             assert!(String::from_utf8_lossy(&received.payload).contains("Batch message"));
             handles.push(handle);

--- a/kincir/src/memory/advanced_tests.rs
+++ b/kincir/src/memory/advanced_tests.rs
@@ -180,7 +180,7 @@ mod tests {
         // Both topics should be removed since neither has subscribers
         // and both should be idle after the wait
         assert!(
-            removed.len() >= 1,
+            !removed.is_empty(),
             "Expected at least 1 topic to be removed, got {}",
             removed.len()
         );

--- a/kincir/src/memory/example.rs
+++ b/kincir/src/memory/example.rs
@@ -149,7 +149,7 @@ mod integration_tests {
         for i in 0..message_count {
             messages.push(
                 Message::new(format!("Message #{}", i).into_bytes())
-                    .with_metadata("sequence", &i.to_string()),
+                    .with_metadata("sequence", i.to_string()),
             );
         }
 

--- a/kincir/src/memory/publisher.rs
+++ b/kincir/src/memory/publisher.rs
@@ -95,7 +95,7 @@ mod tests {
         let publisher = InMemoryPublisher::new(broker.clone());
 
         assert!(publisher.is_connected());
-        assert_eq!(Arc::ptr_eq(&publisher.broker, &broker), true);
+        assert!(Arc::ptr_eq(&publisher.broker, &broker));
     }
 
     #[tokio::test]

--- a/kincir/src/memory/subscriber.rs
+++ b/kincir/src/memory/subscriber.rs
@@ -257,7 +257,7 @@ mod tests {
         assert!(subscriber.is_connected());
         assert!(!subscriber.is_subscribed());
         assert_eq!(subscriber.subscribed_topic(), None);
-        assert_eq!(Arc::ptr_eq(&subscriber.broker, &broker), true);
+        assert!(Arc::ptr_eq(&subscriber.broker, &broker));
     }
 
     #[tokio::test]

--- a/kincir/src/memory/working_ack_test.rs
+++ b/kincir/src/memory/working_ack_test.rs
@@ -17,7 +17,7 @@ mod working_tests {
             .with_metadata("test", "true")
             .with_metadata(
                 "created_at",
-                &std::time::SystemTime::now()
+                std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap()
                     .as_secs()
@@ -379,7 +379,7 @@ mod working_tests {
             subscriber
                 .subscribe(topic)
                 .await
-                .expect(&format!("Failed to subscribe to {}", topic));
+                .unwrap_or_else(|_| panic!("Failed to subscribe to {}", topic));
         }
 
         // Verify subscription state
@@ -403,7 +403,7 @@ mod working_tests {
             publisher
                 .publish(topic, topic_messages)
                 .await
-                .expect(&format!("Failed to publish to {}", topic));
+                .unwrap_or_else(|_| panic!("Failed to publish to {}", topic));
             total_expected += messages_per_topic;
         }
 

--- a/kincir/src/mqtt/tests.rs
+++ b/kincir/src/mqtt/tests.rs
@@ -694,7 +694,7 @@ mod mqtt_performance_unit_tests {
 
     #[test]
     fn test_qos_determination_performance() {
-        let qos_levels = vec![QoS::AtMostOnce, QoS::AtLeastOnce, QoS::ExactlyOnce];
+        let qos_levels = [QoS::AtMostOnce, QoS::AtLeastOnce, QoS::ExactlyOnce];
 
         let start = std::time::Instant::now();
         let iterations = 10000;

--- a/kincir/src/rabbitmq/tests.rs
+++ b/kincir/src/rabbitmq/tests.rs
@@ -307,11 +307,9 @@ mod rabbitmq_integration_unit_tests {
     fn test_batch_acknowledgment_logic() {
         // Test the logic for batch acknowledgment with RabbitMQ delivery tags
         let now = SystemTime::now();
-        let handles = vec![
-            RabbitMQAckHandle::new("msg1".to_string(), "queue".to_string(), now, 1, 100),
+        let handles = [RabbitMQAckHandle::new("msg1".to_string(), "queue".to_string(), now, 1, 100),
             RabbitMQAckHandle::new("msg2".to_string(), "queue".to_string(), now, 1, 101),
-            RabbitMQAckHandle::new("msg3".to_string(), "queue".to_string(), now, 1, 102),
-        ];
+            RabbitMQAckHandle::new("msg3".to_string(), "queue".to_string(), now, 1, 102)];
 
         // Find the highest delivery tag for batch acknowledgment
         let max_delivery_tag = handles.iter().map(|h| h.delivery_tag()).max().unwrap_or(0);

--- a/kincir/tests/comprehensive_integration_tests.rs
+++ b/kincir/tests/comprehensive_integration_tests.rs
@@ -21,11 +21,11 @@ fn create_integration_test_messages(count: usize, prefix: &str) -> Vec<Message> 
             let payload = format!("{} integration message {}", prefix, i).into_bytes();
             let mut msg = Message::new(payload);
             msg = msg.with_metadata("test_type", "integration");
-            msg = msg.with_metadata("sequence", &i.to_string());
+            msg = msg.with_metadata("sequence", i.to_string());
             msg = msg.with_metadata("prefix", prefix);
             msg = msg.with_metadata(
                 "created_at",
-                &SystemTime::now()
+                SystemTime::now()
                     .duration_since(SystemTime::UNIX_EPOCH)
                     .unwrap()
                     .as_secs()
@@ -45,7 +45,7 @@ fn create_test_handler() -> HandlerFunc {
             processed = processed.with_metadata("processed", "true");
             processed = processed.with_metadata(
                 "processed_at",
-                &SystemTime::now()
+                SystemTime::now()
                     .duration_since(SystemTime::UNIX_EPOCH)
                     .unwrap()
                     .as_secs()
@@ -90,8 +90,8 @@ mod cross_backend_consistency_tests {
         for i in 0..5 {
             let (received, handle) = timeout(Duration::from_secs(5), subscriber.receive_with_ack())
                 .await
-                .expect(&format!("Timeout waiting for message {}", i + 1))
-                .expect(&format!("Failed to receive message {}", i + 1));
+                .unwrap_or_else(|_| panic!("Timeout waiting for message {}", i + 1))
+                .unwrap_or_else(|_| panic!("Failed to receive message {}", i + 1));
 
             // Verify message properties
             assert_eq!(handle.topic(), topic);
@@ -267,8 +267,8 @@ mod high_throughput_integration_tests {
             let (received, handle) =
                 timeout(Duration::from_secs(30), subscriber.receive_with_ack())
                     .await
-                    .expect(&format!("Timeout waiting for message {}", i + 1))
-                    .expect(&format!("Failed to receive message {}", i + 1));
+                    .unwrap_or_else(|_| panic!("Timeout waiting for message {}", i + 1))
+                    .unwrap_or_else(|_| panic!("Failed to receive message {}", i + 1));
 
             // Verify message integrity
             assert!(String::from_utf8_lossy(&received.payload).contains("HighThroughput"));
@@ -281,7 +281,7 @@ mod high_throughput_integration_tests {
             subscriber
                 .ack(handle)
                 .await
-                .expect(&format!("Failed to acknowledge message {}", i + 1));
+                .unwrap_or_else(|_| panic!("Failed to acknowledge message {}", i + 1));
             let ack_msg_duration = ack_msg_start.elapsed();
 
             ack_times.push(ack_msg_duration);
@@ -492,11 +492,12 @@ mod end_to_end_workflow_tests {
         let mut negative_acks = 0;
         let mut batch_handles = Vec::new();
 
+        #[allow(clippy::needless_range_loop)]
         for i in 0..10 {
             let (received, handle) = timeout(Duration::from_secs(5), subscriber.receive_with_ack())
                 .await
-                .expect(&format!("Timeout waiting for message {}", i + 1))
-                .expect(&format!("Failed to receive message {}", i + 1));
+                .unwrap_or_else(|_| panic!("Timeout waiting for message {}", i + 1))
+                .unwrap_or_else(|_| panic!("Failed to receive message {}", i + 1));
 
             // Verify message integrity
             assert_eq!(received.payload, test_messages[i].payload);
@@ -607,20 +608,17 @@ mod end_to_end_workflow_tests {
         ] {
             let mut processed_count = 0;
 
+            #[allow(clippy::needless_range_loop)]
             for i in 0..3 {
                 let (received, handle) =
                     timeout(Duration::from_secs(5), subscriber.receive_with_ack())
                         .await
-                        .expect(&format!(
-                            "Timeout waiting for message {} from {}",
+                        .unwrap_or_else(|_| panic!("Timeout waiting for message {} from {}",
                             i + 1,
-                            topic
-                        ))
-                        .expect(&format!(
-                            "Failed to receive message {} from {}",
+                            topic))
+                        .unwrap_or_else(|_| panic!("Failed to receive message {} from {}",
                             i + 1,
-                            topic
-                        ));
+                            topic));
 
                 // Verify message belongs to correct topic
                 assert_eq!(handle.topic(), topic);
@@ -630,7 +628,7 @@ mod end_to_end_workflow_tests {
                 subscriber
                     .ack(handle)
                     .await
-                    .expect(&format!("Failed to acknowledge message from {}", topic));
+                    .unwrap_or_else(|_| panic!("Failed to acknowledge message from {}", topic));
                 processed_count += 1;
             }
 
@@ -733,8 +731,8 @@ mod performance_validation_tests {
 
             let (received, handle) = timeout(Duration::from_secs(5), subscriber.receive_with_ack())
                 .await
-                .expect(&format!("Timeout waiting for message {}", i + 1))
-                .expect(&format!("Failed to receive message {}", i + 1));
+                .unwrap_or_else(|_| panic!("Timeout waiting for message {}", i + 1))
+                .unwrap_or_else(|_| panic!("Failed to receive message {}", i + 1));
 
             let receive_latency = start.elapsed();
 
@@ -808,7 +806,7 @@ mod performance_validation_tests {
             .map(|i| {
                 let payload = vec![0u8; message_size];
                 let mut msg = Message::new(payload);
-                msg = msg.with_metadata("sequence", &i.to_string());
+                msg = msg.with_metadata("sequence", i.to_string());
                 msg = msg.with_metadata("test_type", "memory_test");
                 msg
             })
@@ -846,8 +844,8 @@ mod performance_validation_tests {
             let (received, handle) =
                 timeout(Duration::from_secs(10), subscriber.receive_with_ack())
                     .await
-                    .expect(&format!("Timeout waiting for message {}", i + 1))
-                    .expect(&format!("Failed to receive message {}", i + 1));
+                    .unwrap_or_else(|_| panic!("Timeout waiting for message {}", i + 1))
+                    .unwrap_or_else(|_| panic!("Failed to receive message {}", i + 1));
 
             // Verify message
             assert_eq!(received.payload.len(), message_size);

--- a/kincir/tests/cross_backend_ack_tests.rs
+++ b/kincir/tests/cross_backend_ack_tests.rs
@@ -112,8 +112,8 @@ async fn test_batch_acknowledgment_consistency() {
             Duration::from_secs(5),
             subscriber.receive_with_ack()
         ).await
-            .expect(&format!("Timeout waiting for message {}", i + 1))
-            .expect(&format!("Failed to receive message {}", i + 1));
+            .unwrap_or_else(|_| panic!("Timeout waiting for message {}", i + 1))
+            .unwrap_or_else(|_| panic!("Failed to receive message {}", i + 1));
 
         received_messages.push(message);
         ack_handles.push(handle);
@@ -497,12 +497,12 @@ async fn test_acknowledgment_performance_consistency() {
             Duration::from_secs(10),
             subscriber.receive_with_ack()
         ).await
-            .expect(&format!("Timeout waiting for message {}", i + 1))
-            .expect(&format!("Failed to receive message {}", i + 1));
+            .unwrap_or_else(|_| panic!("Timeout waiting for message {}", i + 1))
+            .unwrap_or_else(|_| panic!("Failed to receive message {}", i + 1));
 
         let ack_start = std::time::Instant::now();
         subscriber.ack(handle).await
-            .expect(&format!("Failed to acknowledge message {}", i + 1));
+            .unwrap_or_else(|_| panic!("Failed to acknowledge message {}", i + 1));
         let ack_duration = ack_start.elapsed();
 
         ack_times.push(ack_duration);

--- a/kincir/tests/high_throughput_ack_tests.rs
+++ b/kincir/tests/high_throughput_ack_tests.rs
@@ -27,9 +27,9 @@ fn create_sequenced_messages(count: usize, prefix: &str, start_seq: usize) -> Ve
         .map(|i| {
             let seq = start_seq + i;
             Message::new(format!("{} message {}", prefix, seq).into_bytes())
-                .with_metadata("sequence", &seq.to_string())
+                .with_metadata("sequence", seq.to_string())
                 .with_metadata("batch_id", prefix)
-                .with_metadata("created_at", &chrono::Utc::now().to_rfc3339())
+                .with_metadata("created_at", chrono::Utc::now().to_rfc3339())
         })
         .collect()
 }
@@ -76,8 +76,8 @@ async fn test_high_volume_single_subscriber() {
             Duration::from_secs(30),
             subscriber.receive_with_ack()
         ).await
-            .expect(&format!("Timeout waiting for message {}", i + 1))
-            .expect(&format!("Failed to receive message {}", i + 1));
+            .unwrap_or_else(|_| panic!("Timeout waiting for message {}", i + 1))
+            .unwrap_or_else(|_| panic!("Failed to receive message {}", i + 1));
 
         // Verify message content
         assert!(String::from_utf8_lossy(&message.payload).contains("HighVolume"));
@@ -85,7 +85,7 @@ async fn test_high_volume_single_subscriber() {
 
         let ack_start = Instant::now();
         subscriber.ack(handle).await
-            .expect(&format!("Failed to acknowledge message {}", i + 1));
+            .unwrap_or_else(|_| panic!("Failed to acknowledge message {}", i + 1));
         let ack_duration = ack_start.elapsed();
 
         ack_times.push(ack_duration);
@@ -174,14 +174,14 @@ async fn test_concurrent_publishers_single_subscriber() {
             Duration::from_secs(30),
             subscriber.receive_with_ack()
         ).await
-            .expect(&format!("Timeout waiting for message {}", i + 1))
-            .expect(&format!("Failed to receive message {}", i + 1));
+            .unwrap_or_else(|_| panic!("Timeout waiting for message {}", i + 1))
+            .unwrap_or_else(|_| panic!("Failed to receive message {}", i + 1));
 
         received_messages.push(message);
 
         let ack_start = Instant::now();
         subscriber.ack(handle).await
-            .expect(&format!("Failed to acknowledge message {}", i + 1));
+            .unwrap_or_else(|_| panic!("Failed to acknowledge message {}", i + 1));
         let ack_duration = ack_start.elapsed();
 
         ack_times.push(ack_duration);
@@ -194,9 +194,10 @@ async fn test_concurrent_publishers_single_subscriber() {
     let receive_duration = receive_start.elapsed();
 
     // Verify all publishers' messages were received
-    let mut publisher_counts = vec![0; CONCURRENT_PUBLISHERS];
+    let mut publisher_counts = [0; CONCURRENT_PUBLISHERS];
     for message in &received_messages {
         let payload = String::from_utf8_lossy(&message.payload);
+        #[allow(clippy::needless_range_loop)]
         for pub_id in 0..CONCURRENT_PUBLISHERS {
             if payload.contains(&format!("Pub{}", pub_id)) {
                 publisher_counts[pub_id] += 1;
@@ -362,7 +363,7 @@ async fn test_batch_acknowledgment_high_throughput() {
         );
         
         publisher.publish("batch_ack", batch_messages).await
-            .expect(&format!("Failed to publish batch {}", batch_id));
+            .unwrap_or_else(|_| panic!("Failed to publish batch {}", batch_id));
     }
 
     let publish_duration = publish_start.elapsed();
@@ -382,8 +383,8 @@ async fn test_batch_acknowledgment_high_throughput() {
                 Duration::from_secs(10),
                 subscriber.receive_with_ack()
             ).await
-                .expect(&format!("Timeout waiting for message {} in batch {}", i, batch_id))
-                .expect(&format!("Failed to receive message {} in batch {}", i, batch_id));
+                .unwrap_or_else(|_| panic!("Timeout waiting for message {} in batch {}", i, batch_id))
+                .unwrap_or_else(|_| panic!("Failed to receive message {} in batch {}", i, batch_id));
 
             // Verify message is from expected batch
             let payload = String::from_utf8_lossy(&message.payload);
@@ -397,7 +398,7 @@ async fn test_batch_acknowledgment_high_throughput() {
         // Batch acknowledge
         let batch_ack_start_time = Instant::now();
         subscriber.ack_batch(batch_handles).await
-            .expect(&format!("Failed to batch acknowledge batch {}", batch_id));
+            .unwrap_or_else(|_| panic!("Failed to batch acknowledge batch {}", batch_id));
         let batch_ack_duration = batch_ack_start_time.elapsed();
 
         total_processed += BATCH_SIZE;
@@ -617,8 +618,8 @@ async fn test_memory_usage_under_high_load() {
             Duration::from_secs(30),
             subscriber.receive_with_ack()
         ).await
-            .expect(&format!("Timeout waiting for message {}", i + 1))
-            .expect(&format!("Failed to receive message {}", i + 1));
+            .unwrap_or_else(|_| panic!("Timeout waiting for message {}", i + 1))
+            .unwrap_or_else(|_| panic!("Failed to receive message {}", i + 1));
 
         handles.push(handle);
 
@@ -666,8 +667,8 @@ fn create_large_messages(count: usize, size_bytes: usize) -> Vec<Message> {
     (0..count)
         .map(|i| {
             Message::new(large_payload.clone())
-                .with_metadata("message_id", &i.to_string())
-                .with_metadata("size", &size_bytes.to_string())
+                .with_metadata("message_id", i.to_string())
+                .with_metadata("size", size_bytes.to_string())
         })
         .collect()
 }

--- a/kincir/tests/kafka_ack_tests.rs
+++ b/kincir/tests/kafka_ack_tests.rs
@@ -7,16 +7,12 @@
 use kincir::ack::{AckHandle, AckSubscriber};
 use kincir::kafka::{KafkaAckHandle, KafkaAckSubscriber, KafkaPublisher};
 use kincir::{Message, Publisher};
-use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use tokio::time::timeout;
 
 // Helper function to check if Kafka is available
 async fn is_kafka_available() -> bool {
-    match tokio::net::TcpStream::connect("127.0.0.1:9092").await {
-        Ok(_) => true,
-        Err(_) => false,
-    }
+    (tokio::net::TcpStream::connect("127.0.0.1:9092").await).is_ok()
 }
 
 // Skip test if Kafka is not available
@@ -261,11 +257,12 @@ async fn test_kafka_batch_acknowledgment() {
 
     // Receive messages and collect acknowledgment handles
     let mut ack_handles = Vec::new();
+    #[allow(clippy::needless_range_loop)]
     for i in 0..3 {
         let (received_message, ack_handle) = timeout(Duration::from_secs(10), subscriber.receive_with_ack())
             .await
-            .expect(&format!("Timeout waiting for message {}", i + 1))
-            .expect(&format!("Failed to receive message {}", i + 1));
+            .unwrap_or_else(|_| panic!("Timeout waiting for message {}", i + 1))
+            .unwrap_or_else(|_| panic!("Failed to receive message {}", i + 1));
         
         // Verify message content
         assert_eq!(received_message.payload, messages[i].payload);
@@ -309,11 +306,12 @@ async fn test_kafka_batch_negative_acknowledgment() {
 
     // Receive messages and collect acknowledgment handles
     let mut ack_handles = Vec::new();
+    #[allow(clippy::needless_range_loop)]
     for i in 0..2 {
         let (received_message, ack_handle) = timeout(Duration::from_secs(10), subscriber.receive_with_ack())
             .await
-            .expect(&format!("Timeout waiting for message {}", i + 1))
-            .expect(&format!("Failed to receive message {}", i + 1));
+            .unwrap_or_else(|_| panic!("Timeout waiting for message {}", i + 1))
+            .unwrap_or_else(|_| panic!("Failed to receive message {}", i + 1));
         
         // Verify message content
         assert_eq!(received_message.payload, messages[i].payload);

--- a/kincir/tests/mqtt_ack_tests.rs
+++ b/kincir/tests/mqtt_ack_tests.rs
@@ -7,16 +7,12 @@
 use kincir::ack::{AckHandle, AckSubscriber};
 use kincir::mqtt::{MQTTAckHandle, MQTTAckSubscriber, MQTTPublisher, QoS};
 use kincir::{Message, Publisher};
-use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use tokio::time::timeout;
 
 // Helper function to check if MQTT broker is available
 async fn is_mqtt_available() -> bool {
-    match tokio::net::TcpStream::connect("127.0.0.1:1883").await {
-        Ok(_) => true,
-        Err(_) => false,
-    }
+    (tokio::net::TcpStream::connect("127.0.0.1:1883").await).is_ok()
 }
 
 // Skip test if MQTT broker is not available
@@ -358,8 +354,8 @@ async fn test_mqtt_batch_acknowledgment() {
     for i in 0..3 {
         let (received_message, ack_handle) = timeout(Duration::from_secs(10), subscriber.receive_with_ack())
             .await
-            .expect(&format!("Timeout waiting for message {}", i + 1))
-            .expect(&format!("Failed to receive message {}", i + 1));
+            .unwrap_or_else(|_| panic!("Timeout waiting for message {}", i + 1))
+            .unwrap_or_else(|_| panic!("Failed to receive message {}", i + 1));
         
         // Verify message content (order may vary)
         assert!(messages.iter().any(|m| m.payload == received_message.payload));
@@ -413,8 +409,8 @@ async fn test_mqtt_batch_negative_acknowledgment() {
     for i in 0..2 {
         let (received_message, ack_handle) = timeout(Duration::from_secs(10), subscriber.receive_with_ack())
             .await
-            .expect(&format!("Timeout waiting for message {}", i + 1))
-            .expect(&format!("Failed to receive message {}", i + 1));
+            .unwrap_or_else(|_| panic!("Timeout waiting for message {}", i + 1))
+            .unwrap_or_else(|_| panic!("Failed to receive message {}", i + 1));
         
         // Verify message content (order may vary)
         assert!(messages.iter().any(|m| m.payload == received_message.payload));

--- a/kincir/tests/rabbitmq_ack_tests.rs
+++ b/kincir/tests/rabbitmq_ack_tests.rs
@@ -7,16 +7,12 @@
 use kincir::ack::{AckHandle, AckSubscriber};
 use kincir::rabbitmq::{RabbitMQAckHandle, RabbitMQAckSubscriber, RabbitMQPublisher};
 use kincir::{Message, Publisher};
-use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use tokio::time::timeout;
 
 // Helper function to check if RabbitMQ is available
 async fn is_rabbitmq_available() -> bool {
-    match tokio::net::TcpStream::connect("127.0.0.1:5672").await {
-        Ok(_) => true,
-        Err(_) => false,
-    }
+    (tokio::net::TcpStream::connect("127.0.0.1:5672").await).is_ok()
 }
 
 // Skip test if RabbitMQ is not available
@@ -248,11 +244,12 @@ async fn test_rabbitmq_batch_acknowledgment() {
 
     // Receive messages and collect acknowledgment handles
     let mut ack_handles = Vec::new();
+    #[allow(clippy::needless_range_loop)]
     for i in 0..3 {
         let (received_message, ack_handle) = timeout(Duration::from_secs(5), subscriber.receive_with_ack())
             .await
-            .expect(&format!("Timeout waiting for message {}", i + 1))
-            .expect(&format!("Failed to receive message {}", i + 1));
+            .unwrap_or_else(|_| panic!("Timeout waiting for message {}", i + 1))
+            .unwrap_or_else(|_| panic!("Failed to receive message {}", i + 1));
         
         // Verify message content
         assert_eq!(received_message.payload, messages[i].payload);
@@ -296,11 +293,12 @@ async fn test_rabbitmq_batch_negative_acknowledgment() {
 
     // Receive messages and collect acknowledgment handles
     let mut ack_handles = Vec::new();
+    #[allow(clippy::needless_range_loop)]
     for i in 0..2 {
         let (received_message, ack_handle) = timeout(Duration::from_secs(5), subscriber.receive_with_ack())
             .await
-            .expect(&format!("Timeout waiting for message {}", i + 1))
-            .expect(&format!("Failed to receive message {}", i + 1));
+            .unwrap_or_else(|_| panic!("Timeout waiting for message {}", i + 1))
+            .unwrap_or_else(|_| panic!("Failed to receive message {}", i + 1));
         
         // Verify message content
         assert_eq!(received_message.payload, messages[i].payload);

--- a/kincir/tests/router_ack_tests.rs
+++ b/kincir/tests/router_ack_tests.rs
@@ -17,7 +17,7 @@ use tokio::time::{sleep, timeout};
 fn create_test_message(content: &str) -> Message {
     Message::new(content.as_bytes().to_vec())
         .with_metadata("test", "true")
-        .with_metadata("timestamp", &chrono::Utc::now().to_rfc3339())
+        .with_metadata("timestamp", chrono::Utc::now().to_rfc3339())
 }
 
 // Helper function to create a test handler that always succeeds


### PR DESCRIPTION
## Summary

`cargo clippy -p kincir --all-targets` is now **clean** — both with default features and with `--features broker-integration`. This clears the ~66 clippy lints that lived in the test and benchmark code (the library itself was already clippy-clean).

## Changes

Mostly machine-applicable fixes via `cargo clippy --fix`:
- `expect_fun_call`: `format!()` inside `.expect(...)` → `unwrap_or_else(|_| panic!(...))` (also makes the message lazy)
- `needless_borrow`: drop redundant `&` on arguments
- `useless_vec`: `vec![..]` → `[..]` where a slice suffices
- `bool_assert_comparison`: `assert_eq!(x, true)` → `assert!(x)`
- `unnecessary_cast` and a redundant double-paren leftover
- `redundant_pattern_matching`: `if let Ok(_) = ...` → `.is_ok()`
- removed a couple of unused imports

Manual:
- `#[allow(clippy::module_inception)]` on the `backend::tests` inner module
- `#[allow(clippy::needless_range_loop)]` on a few test loops whose index is also used for message numbering / receive counts (so a range loop reads more clearly than `enumerate`)

## Testing
- `cargo clippy -p kincir --all-targets`: 0 warnings
- `cargo clippy -p kincir --all-targets --features broker-integration`: 0 warnings
- `cargo test -p kincir`: full suite green (166 lib + integration suites + 12 doctests, 0 failures)

## Notes
- All changes are confined to `#[cfg(test)]` modules, integration tests, and benches; no production code behavior changes.