### PR TITLE
Refresh README code examples to match the current API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "examples/protobuf-example",
     "examples/mqtt-example",
     "examples/mqtt-to-kafka-example",
+    "examples/mqtt-to-rabbitmq-example",
     "examples/in-memory-example",
     "examples/ack-example"
 ]

--- a/README.md
+++ b/README.md
@@ -58,20 +58,27 @@ let message = subscriber.receive().await?;
 Kincir v0.2.0 introduces comprehensive message acknowledgment support across all backends:
 
 ```rust
-use kincir::rabbitmq::RabbitMQAckSubscriber;
-use kincir::{AckSubscriber, Message};
+use kincir::ack::AckSubscriber;
+use kincir::memory::{InMemoryAckSubscriber, InMemoryBroker, InMemoryPublisher};
+use kincir::{Message, Publisher};
+use std::sync::Arc;
 
-let mut subscriber = RabbitMQAckSubscriber::new("amqp://localhost:5672", "my-queue");
+let broker = Arc::new(InMemoryBroker::with_default_config());
+let publisher = InMemoryPublisher::new(broker.clone());
+let mut subscriber = InMemoryAckSubscriber::new(broker.clone());
+
 subscriber.subscribe("orders").await?;
+publisher.publish("orders", vec![Message::new(b"Order #1234".to_vec())]).await?;
 
+// Receive a message together with an acknowledgment handle
 let (message, ack_handle) = subscriber.receive_with_ack().await?;
-// Process the message
 println!("Processing: {:?}", message);
 
-// Acknowledge successful processing
-ack_handle.ack().await?;
-// Or reject and requeue on error
-// ack_handle.nack(true).await?;
+// Acknowledge successful processing. The same `AckSubscriber` trait is
+// implemented by the RabbitMQ, Kafka, and MQTT backends.
+subscriber.ack(ack_handle).await?;
+// Or negatively acknowledge and requeue on error:
+// subscriber.nack(ack_handle, true).await?;
 ```
 
 ### MQTT Support
@@ -79,15 +86,19 @@ ack_handle.ack().await?;
 Full MQTT implementation with QoS handling for IoT and real-time applications:
 
 ```rust
-use kincir::mqtt::{MQTTPublisher, MQTTSubscriber};
-use rumqttc::QoS;
+use kincir::mqtt::{MQTTPublisher, MQTTSubscriber, QoS};
+use kincir::{Message, Publisher, Subscriber};
 
-let publisher = MQTTPublisher::new("mqtt://localhost:1883", "client-pub");
-let mut subscriber = MQTTSubscriber::new("mqtt://localhost:1883", "client-sub");
+// Publisher and subscriber are bound to a broker URL and topic; QoS is set on
+// the subscriber. Both constructors return a `Result`.
+let publisher = MQTTPublisher::new("mqtt://localhost:1883", "sensors/temperature")?;
+let mut subscriber =
+    MQTTSubscriber::new("mqtt://localhost:1883", "sensors/temperature", QoS::AtLeastOnce)?;
 
 subscriber.subscribe("sensors/temperature").await?;
-publisher.publish_with_qos("sensors/temperature", 
-    vec![Message::new(b"25.5".to_vec())], QoS::AtLeastOnce).await?;
+publisher
+    .publish("sensors/temperature", vec![Message::new(b"25.5".to_vec())])
+    .await?;
 ```
 
 ### MQTT to RabbitMQ Tunnel
@@ -133,9 +144,9 @@ let message = message.with_metadata("content-type", "text/plain");
 The Router is a central component that handles message flow between publishers and subscribers:
 
 ```rust
+use kincir::logging::StdLogger;
 use kincir::rabbitmq::{RabbitMQPublisher, RabbitMQSubscriber};
-use kincir::router::{Router, Logger, StdLogger};
-use kincir::Message;
+use kincir::{HandlerFunc, Message, Router};
 use std::sync::Arc;
 
 #[tokio::main]
@@ -143,16 +154,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Initialize logger
     let logger = Arc::new(StdLogger::new(true, true));
 
-    // Configure message brokers
-    let publisher = Arc::new(RabbitMQPublisher::new("amqp://localhost:5672"));
-    let subscriber = Arc::new(RabbitMQSubscriber::new("amqp://localhost:5672", "my-queue"));
+    // Configure message brokers (constructors are async and return a Result)
+    let publisher = Arc::new(RabbitMQPublisher::new("amqp://localhost:5672").await?);
+    // The Router needs the subscriber wrapped in Arc<Mutex<...>>
+    let subscriber = RabbitMQSubscriber::new("amqp://localhost:5672").await?;
+    let subscriber = Arc::new(tokio::sync::Mutex::new(subscriber));
 
     // Define message handler
-    let handler = Arc::new(|msg: Message| {
+    let handler: HandlerFunc = Arc::new(|msg: Message| {
         Box::pin(async move {
-            // Process the message
-            let mut processed_msg = msg;
-            processed_msg.set_metadata("processed", "true");
+            // Process the message (Message uses a consuming builder API)
+            let processed_msg = msg.with_metadata("processed", "true");
             Ok(vec![processed_msg])
         })
     });
@@ -191,7 +203,7 @@ async fn publish_example<P: Publisher>(publisher: &P) -> Result<(), P::Error> {
 use kincir::Subscriber;
 
 // Subscribe and receive messages
-async fn subscribe_example<S: Subscriber>(subscriber: &S) -> Result<(), S::Error> {
+async fn subscribe_example<S: Subscriber>(subscriber: &mut S) -> Result<(), S::Error> {
     // Subscribe to a topic
     subscriber.subscribe("my-topic").await?;
     
@@ -210,13 +222,13 @@ async fn subscribe_example<S: Subscriber>(subscriber: &S) -> Result<(), S::Error
 Kincir provides Kafka support through the `kafka` module:
 
 ```rust
-use kincir::kafka::{KafkaPublisher, KafkaSubscriber};
+use kincir::kafka::KafkaPublisher;
 
-// Configure Kafka publisher
-let publisher = KafkaPublisher::new("localhost:9092");
+// Kafka takes a list of broker addresses; construction returns a `Result`.
+let publisher = KafkaPublisher::new(vec!["localhost:9092".to_string()])?;
 
-// Configure Kafka subscriber
-let subscriber = KafkaSubscriber::new("localhost:9092", "consumer-group-id");
+// The Kafka subscriber is typically driven by a `Router`; see
+// `examples/kafka-example` for a complete subscriber + router setup.
 ```
 
 ### RabbitMQ
@@ -226,11 +238,9 @@ RabbitMQ support is available through the `rabbitmq` module:
 ```rust
 use kincir::rabbitmq::{RabbitMQPublisher, RabbitMQSubscriber};
 
-// Configure RabbitMQ publisher
-let publisher = RabbitMQPublisher::new("amqp://localhost:5672");
-
-// Configure RabbitMQ subscriber
-let subscriber = RabbitMQSubscriber::new("amqp://localhost:5672", "my-queue");
+// Both constructors are async and return a `Result`.
+let publisher = RabbitMQPublisher::new("amqp://localhost:5672").await?;
+let subscriber = RabbitMQSubscriber::new("amqp://localhost:5672").await?;
 ```
 
 ## Message Structure
@@ -251,9 +261,8 @@ use kincir::Message;
 // Define a message handler
 let handler = |msg: Message| {
     Box::pin(async move {
-        // Process the message
-        let mut processed_msg = msg;
-        processed_msg.set_metadata("processed", "true");
+        // Process the message (metadata is set via the consuming builder)
+        let processed_msg = msg.with_metadata("processed", "true");
         Ok(vec![processed_msg])
     })
 };

--- a/examples/kafka-example/src/main.rs
+++ b/examples/kafka-example/src/main.rs
@@ -1,6 +1,6 @@
 use kincir::kafka::{KafkaPublisher, KafkaSubscriber};
 use kincir::logging::StdLogger;
-use kincir::{HandlerFunc, Logger, Message, Publisher, Router, Subscriber};
+use kincir::{HandlerFunc, Message, Publisher, Router, Subscriber};
 use std::sync::Arc;
 use tokio::sync::mpsc;
 

--- a/examples/mqtt-to-rabbitmq-example/Cargo.toml
+++ b/examples/mqtt-to-rabbitmq-example/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-kincir = { path = "../../" } # Adjust path as necessary
+kincir = { path = "../../kincir", features = ["logging"] }
 tokio = { version = "1", features = ["full"] }
 dotenvy = "0.15"
 tracing = "0.1"

--- a/kincir/examples/ack_example.rs
+++ b/kincir/examples/ack_example.rs
@@ -3,7 +3,7 @@
 //! This example shows how to use the new acknowledgment functionality to ensure
 //! reliable message processing with manual acknowledgment control.
 
-use kincir::ack::{AckConfig, AckMode, AckSubscriber};
+use kincir::ack::{AckConfig, AckHandle, AckSubscriber};
 use kincir::memory::{InMemoryBroker, InMemoryConfig, InMemoryPublisher, InMemoryAckSubscriber};
 use kincir::{Publisher, Message};
 use std::sync::Arc;
@@ -55,8 +55,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let (message, ack_handle) = ack_subscriber.receive_with_ack().await?;
         
         let order_text = String::from_utf8_lossy(&message.payload);
-        let customer = message.metadata.get("customer").unwrap_or(&"Unknown".to_string());
-        let priority = message.metadata.get("priority").unwrap_or(&"normal".to_string());
+        let customer = message
+            .metadata
+            .get("customer")
+            .map(|s| s.as_str())
+            .unwrap_or("Unknown");
+        let priority = message
+            .metadata
+            .get("priority")
+            .map(|s| s.as_str())
+            .unwrap_or("normal");
         
         println!("📨 Received: {}", order_text);
         println!("   Customer: {}, Priority: {}", customer, priority);
@@ -117,10 +125,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Show broker statistics
     if let Some(stats) = publisher.stats() {
         println!("\n📊 Broker Statistics:");
-        println!("   Messages Published: {}", stats.messages_published());
-        println!("   Messages Consumed: {}", stats.messages_consumed());
-        println!("   Active Topics: {}", stats.active_topics());
-        println!("   Uptime: {:?}", stats.uptime());
+        println!("   Messages Published: {}", stats.messages_published);
+        println!("   Messages Consumed: {}", stats.messages_consumed);
+        println!("   Active Topics: {}", stats.active_topics);
+        println!("   Uptime: {:?}", stats.uptime);
     }
     
     // Show broker health
@@ -170,7 +178,7 @@ async fn demonstrate_error_handling() -> Result<(), Box<dyn std::error::Error>> 
     println!("\n🚨 Error Handling Examples:");
     
     let broker = Arc::new(InMemoryBroker::new(InMemoryConfig::for_testing()));
-    let subscriber = InMemoryAckSubscriber::new(broker.clone());
+    let mut subscriber = InMemoryAckSubscriber::new(broker.clone());
     
     // Try to receive without subscribing
     match subscriber.receive_with_ack().await {

--- a/kincir/examples/kafka_ack_example.rs
+++ b/kincir/examples/kafka_ack_example.rs
@@ -1,49 +1,51 @@
-//! RabbitMQ Acknowledgment Example
+//! Kafka Acknowledgment Example
 //!
-//! This example demonstrates how to use RabbitMQ with manual acknowledgment handling.
+//! This example demonstrates how to use Apache Kafka with manual acknowledgment handling.
 //! It shows publishing messages, receiving them with acknowledgment handles, and
 //! performing manual acknowledgment or negative acknowledgment operations.
 //!
 //! Prerequisites:
-//! - RabbitMQ server running on localhost:5672
-//! - Default guest/guest credentials
+//! - Apache Kafka server running on localhost:9092
+//! - Topic creation (topics will be auto-created if auto.create.topics.enable=true)
 //!
-//! Run with: cargo run --example rabbitmq_ack_example
+//! Run with: cargo run --example kafka_ack_example
 
 use kincir::ack::{AckHandle, AckSubscriber};
-use kincir::rabbitmq::{RabbitMQAckSubscriber, RabbitMQPublisher};
+use kincir::kafka::{KafkaAckSubscriber, KafkaPublisher};
 use kincir::{Message, Publisher};
 use std::time::Duration;
 use tokio::time::{sleep, timeout};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    println!("🚀 RabbitMQ Acknowledgment Example");
-    println!("=====================================");
+    println!("🚀 Kafka Acknowledgment Example");
+    println!("=================================");
 
-    // Check if RabbitMQ is available
-    if !is_rabbitmq_available().await {
-        eprintln!("❌ RabbitMQ is not available at localhost:5672");
-        eprintln!("   Please start RabbitMQ server and try again.");
-        eprintln!("   Docker: docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-management");
+    // Check if Kafka is available
+    if !is_kafka_available().await {
+        eprintln!("❌ Kafka is not available at localhost:9092");
+        eprintln!("   Please start Kafka server and try again.");
+        eprintln!("   Docker: docker run -d --name kafka -p 9092:9092 apache/kafka:latest");
         return Ok(());
     }
 
-    println!("✅ RabbitMQ connection available");
+    println!("✅ Kafka connection available");
 
     // Configuration
-    let rabbitmq_uri = "amqp://guest:guest@127.0.0.1:5672";
-    let topic = "ack-example-queue";
+    let brokers = vec!["127.0.0.1:9092".to_string()];
+    let topic = "ack-example-topic";
+    let consumer_group = "ack-example-group";
 
     // Create publisher
-    println!("\n📤 Creating RabbitMQ publisher...");
-    let publisher = RabbitMQPublisher::new(rabbitmq_uri).await?;
+    println!("\n📤 Creating Kafka publisher...");
+    let publisher = KafkaPublisher::new(brokers.clone())?;
     println!("✅ Publisher created successfully");
 
     // Create subscriber with acknowledgment support
-    println!("\n📥 Creating RabbitMQ acknowledgment subscriber...");
-    let mut subscriber = RabbitMQAckSubscriber::new(rabbitmq_uri).await?;
+    println!("\n📥 Creating Kafka acknowledgment subscriber...");
+    let mut subscriber = KafkaAckSubscriber::new(brokers, consumer_group.to_string()).await?;
     println!("✅ Acknowledgment subscriber created successfully");
+    println!("   Consumer Group: {}", subscriber.group_id());
 
     // Subscribe to topic
     println!("\n🔗 Subscribing to topic: {}", topic);
@@ -51,57 +53,57 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("✅ Successfully subscribed to topic");
 
     // Example 1: Basic acknowledgment
-    println!("\n" + "=".repeat(50).as_str());
+    println!("\n{}", "=".repeat(50));
     println!("📋 Example 1: Basic Message Acknowledgment");
-    println!("=".repeat(50));
+    println!("{}", "=".repeat(50));
     
     basic_acknowledgment_example(&publisher, &mut subscriber, topic).await?;
 
     // Example 2: Negative acknowledgment with requeue
-    println!("\n" + "=".repeat(50).as_str());
+    println!("\n{}", "=".repeat(50));
     println!("📋 Example 2: Negative Acknowledgment with Requeue");
-    println!("=".repeat(50));
+    println!("{}", "=".repeat(50));
     
     negative_acknowledgment_example(&publisher, &mut subscriber, topic).await?;
 
     // Example 3: Batch acknowledgment
-    println!("\n" + "=".repeat(50).as_str());
+    println!("\n{}", "=".repeat(50));
     println!("📋 Example 3: Batch Acknowledgment");
-    println!("=".repeat(50));
+    println!("{}", "=".repeat(50));
     
     batch_acknowledgment_example(&publisher, &mut subscriber, topic).await?;
 
-    // Example 4: Error handling and retry logic
-    println!("\n" + "=".repeat(50).as_str());
-    println!("📋 Example 4: Error Handling and Retry Logic");
-    println!("=".repeat(50));
+    // Example 4: Offset management and consumer groups
+    println!("\n{}", "=".repeat(50));
+    println!("📋 Example 4: Offset Management and Consumer Groups");
+    println!("{}", "=".repeat(50));
     
-    error_handling_example(&publisher, &mut subscriber, topic).await?;
+    offset_management_example(&publisher, &mut subscriber, topic).await?;
 
     println!("\n🎉 All examples completed successfully!");
-    println!("   The RabbitMQ acknowledgment system provides reliable message processing");
-    println!("   with manual control over message acknowledgment and requeue behavior.");
+    println!("   The Kafka acknowledgment system provides reliable message processing");
+    println!("   with manual control over offset commits and consumer group coordination.");
 
     Ok(())
 }
 
 async fn basic_acknowledgment_example(
-    publisher: &RabbitMQPublisher,
-    subscriber: &mut RabbitMQAckSubscriber,
+    publisher: &KafkaPublisher,
+    subscriber: &mut KafkaAckSubscriber,
     topic: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("📤 Publishing message for basic acknowledgment...");
     
-    let message = Message::new(b"Hello from RabbitMQ with acknowledgment!".to_vec())
+    let message = Message::new(b"Hello from Kafka with acknowledgment!".to_vec())
         .with_metadata("example", "basic_ack")
-        .with_metadata("timestamp", &chrono::Utc::now().to_rfc3339());
+        .with_metadata("timestamp", chrono::Utc::now().to_rfc3339());
     
     publisher.publish(topic, vec![message.clone()]).await?;
     println!("✅ Message published: {}", String::from_utf8_lossy(&message.payload));
 
     println!("📥 Receiving message with acknowledgment handle...");
     let (received_message, ack_handle) = timeout(
-        Duration::from_secs(10),
+        Duration::from_secs(15),
         subscriber.receive_with_ack()
     ).await??;
 
@@ -113,20 +115,22 @@ async fn basic_acknowledgment_example(
     println!("📋 Acknowledgment handle details:");
     println!("   Message ID: {}", ack_handle.message_id());
     println!("   Topic: {}", ack_handle.topic());
+    println!("   Partition: {}", ack_handle.partition());
+    println!("   Offset: {}", ack_handle.offset());
     println!("   Delivery Count: {}", ack_handle.delivery_count());
     println!("   Is Retry: {}", ack_handle.is_retry());
     println!("   Handle ID: {}", ack_handle.handle_id());
 
-    println!("✅ Acknowledging message...");
+    println!("✅ Acknowledging message (committing offset)...");
     subscriber.ack(ack_handle).await?;
-    println!("✅ Message acknowledged successfully");
+    println!("✅ Message acknowledged successfully - offset committed");
 
     Ok(())
 }
 
 async fn negative_acknowledgment_example(
-    publisher: &RabbitMQPublisher,
-    subscriber: &mut RabbitMQAckSubscriber,
+    publisher: &KafkaPublisher,
+    subscriber: &mut KafkaAckSubscriber,
     topic: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("📤 Publishing message for negative acknowledgment...");
@@ -140,11 +144,12 @@ async fn negative_acknowledgment_example(
 
     println!("📥 Receiving message...");
     let (received_message, ack_handle) = timeout(
-        Duration::from_secs(10),
+        Duration::from_secs(15),
         subscriber.receive_with_ack()
     ).await??;
 
     println!("✅ Message received: {}", String::from_utf8_lossy(&received_message.payload));
+    println!("   Partition: {}, Offset: {}", ack_handle.partition(), ack_handle.offset());
 
     // Simulate processing failure
     let should_process = received_message.metadata.get("should_process")
@@ -154,10 +159,9 @@ async fn negative_acknowledgment_example(
     if !should_process {
         println!("❌ Processing failed - negatively acknowledging with requeue...");
         subscriber.nack(ack_handle, true).await?;
-        println!("✅ Message negatively acknowledged and requeued");
-        
-        // The message is now back in the queue and could be received again
-        println!("💡 Message has been requeued and is available for reprocessing");
+        println!("✅ Message negatively acknowledged (offset NOT committed)");
+        println!("💡 Message will be redelivered on consumer restart or rebalance");
+        println!("   In Kafka, 'requeue' means we don't commit the offset");
     } else {
         println!("✅ Processing successful - acknowledging...");
         subscriber.ack(ack_handle).await?;
@@ -167,8 +171,8 @@ async fn negative_acknowledgment_example(
 }
 
 async fn batch_acknowledgment_example(
-    publisher: &RabbitMQPublisher,
-    subscriber: &mut RabbitMQAckSubscriber,
+    publisher: &KafkaPublisher,
+    subscriber: &mut KafkaAckSubscriber,
     topic: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("📤 Publishing batch of messages...");
@@ -187,89 +191,82 @@ async fn batch_acknowledgment_example(
     
     for i in 0..messages.len() {
         let (received_message, ack_handle) = timeout(
-            Duration::from_secs(10),
+            Duration::from_secs(15),
             subscriber.receive_with_ack()
         ).await??;
         
-        println!("✅ Received message {}: {}", 
+        println!("✅ Received message {}: {} (partition: {}, offset: {})", 
                 i + 1, 
-                String::from_utf8_lossy(&received_message.payload));
+                String::from_utf8_lossy(&received_message.payload),
+                ack_handle.partition(),
+                ack_handle.offset());
         
         ack_handles.push(ack_handle);
     }
 
     println!("📋 Performing batch acknowledgment for {} messages...", ack_handles.len());
+    println!("   Kafka will commit the highest offset for each partition");
+    
     subscriber.ack_batch(ack_handles).await?;
     println!("✅ Batch acknowledgment completed successfully");
-    println!("💡 All messages in the batch were acknowledged with a single operation");
+    println!("💡 All messages in the batch were acknowledged with optimized offset commits");
 
     Ok(())
 }
 
-async fn error_handling_example(
-    publisher: &RabbitMQPublisher,
-    subscriber: &mut RabbitMQAckSubscriber,
+async fn offset_management_example(
+    publisher: &KafkaPublisher,
+    subscriber: &mut KafkaAckSubscriber,
     topic: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    println!("📤 Publishing message for error handling demonstration...");
+    println!("📤 Publishing messages for offset management demonstration...");
     
-    let message = Message::new(b"Message for error handling".to_vec())
-        .with_metadata("simulate_error", "true")
-        .with_metadata("max_retries", "3");
+    let messages = vec![
+        Message::new(b"Offset message 1".to_vec()).with_metadata("process", "true"),
+        Message::new(b"Offset message 2".to_vec()).with_metadata("process", "false"),
+        Message::new(b"Offset message 3".to_vec()).with_metadata("process", "true"),
+    ];
     
-    publisher.publish(topic, vec![message.clone()]).await?;
-    println!("✅ Message published: {}", String::from_utf8_lossy(&message.payload));
+    publisher.publish(topic, messages.clone()).await?;
+    println!("✅ Published {} messages for offset management", messages.len());
 
-    println!("📥 Receiving message and simulating processing with retries...");
+    println!("📥 Processing messages with selective acknowledgment...");
     
-    let mut retry_count = 0;
-    let max_retries = 3;
-    
-    loop {
+    for i in 0..messages.len() {
         let (received_message, ack_handle) = timeout(
-            Duration::from_secs(10),
+            Duration::from_secs(15),
             subscriber.receive_with_ack()
         ).await??;
 
-        retry_count += 1;
-        println!("🔄 Processing attempt {} of {}", retry_count, max_retries);
+        println!("🔄 Processing message {} at offset {}", i + 1, ack_handle.offset());
         
-        // Simulate processing
-        let simulate_error = received_message.metadata.get("simulate_error")
+        // Simulate processing based on metadata
+        let should_process = received_message.metadata.get("process")
             .map(|v| v == "true")
             .unwrap_or(false);
 
-        if simulate_error && retry_count < max_retries {
-            println!("❌ Processing failed (simulated) - attempt {}", retry_count);
-            println!("🔄 Negatively acknowledging with requeue for retry...");
-            subscriber.nack(ack_handle, true).await?;
-            
-            // Add delay before retry
-            sleep(Duration::from_millis(500)).await;
-            continue;
-        } else if simulate_error && retry_count >= max_retries {
-            println!("❌ Max retries exceeded - negatively acknowledging without requeue");
-            println!("💀 Message will be discarded or sent to dead letter queue");
-            subscriber.nack(ack_handle, false).await?;
-            break;
-        } else {
-            println!("✅ Processing successful - acknowledging message");
+        if should_process {
+            println!("✅ Processing successful - acknowledging offset {}", ack_handle.offset());
             subscriber.ack(ack_handle).await?;
-            break;
+        } else {
+            println!("❌ Processing failed - discarding message at offset {}", ack_handle.offset());
+            // Discard by committing offset (skip this message)
+            subscriber.nack(ack_handle, false).await?;
         }
+        
+        // Small delay to demonstrate sequential processing
+        sleep(Duration::from_millis(100)).await;
     }
 
-    println!("📊 Error handling completed:");
-    println!("   Total attempts: {}", retry_count);
-    println!("   Max retries: {}", max_retries);
-    println!("💡 This demonstrates how to implement retry logic with acknowledgments");
+    println!("📊 Offset management completed:");
+    println!("   Consumer group: {}", subscriber.group_id());
+    println!("   Topic: {}", topic);
+    println!("💡 Kafka tracks committed offsets per consumer group and partition");
+    println!("   This enables reliable message processing and consumer failover");
 
     Ok(())
 }
 
-async fn is_rabbitmq_available() -> bool {
-    match tokio::net::TcpStream::connect("127.0.0.1:5672").await {
-        Ok(_) => true,
-        Err(_) => false,
-    }
+async fn is_kafka_available() -> bool {
+    (tokio::net::TcpStream::connect("127.0.0.1:9092").await).is_ok()
 }

--- a/kincir/examples/mqtt_ack_example.rs
+++ b/kincir/examples/mqtt_ack_example.rs
@@ -45,37 +45,37 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("✅ Acknowledgment subscriber created successfully");
 
     // Example 1: QoS 0 - Fire and forget (no acknowledgment needed)
-    println!("\n" + "=".repeat(60).as_str());
+    println!("\n{}", "=".repeat(60));
     println!("📋 Example 1: QoS 0 - Fire and Forget (No Acknowledgment)");
-    println!("=".repeat(60));
+    println!("{}", "=".repeat(60));
     
     qos0_example(&publisher, &mut subscriber, &format!("{}/qos0", base_topic)).await?;
 
     // Example 2: QoS 1 - At least once (acknowledgment required)
-    println!("\n" + "=".repeat(60).as_str());
+    println!("\n{}", "=".repeat(60));
     println!("📋 Example 2: QoS 1 - At Least Once (Acknowledgment Required)");
-    println!("=".repeat(60));
+    println!("{}", "=".repeat(60));
     
     qos1_example(&publisher, &mut subscriber, &format!("{}/qos1", base_topic)).await?;
 
     // Example 3: QoS 2 - Exactly once (acknowledgment required)
-    println!("\n" + "=".repeat(60).as_str());
+    println!("\n{}", "=".repeat(60));
     println!("📋 Example 3: QoS 2 - Exactly Once (Acknowledgment Required)");
-    println!("=".repeat(60));
+    println!("{}", "=".repeat(60));
     
     qos2_example(&publisher, &mut subscriber, &format!("{}/qos2", base_topic)).await?;
 
     // Example 4: Negative acknowledgment and requeue behavior
-    println!("\n" + "=".repeat(60).as_str());
+    println!("\n{}", "=".repeat(60));
     println!("📋 Example 4: Negative Acknowledgment and Requeue Behavior");
-    println!("=".repeat(60));
+    println!("{}", "=".repeat(60));
     
     negative_acknowledgment_example(&publisher, &mut subscriber, &format!("{}/nack", base_topic)).await?;
 
     // Example 5: Batch operations
-    println!("\n" + "=".repeat(60).as_str());
+    println!("\n{}", "=".repeat(60));
     println!("📋 Example 5: Batch Acknowledgment Operations");
-    println!("=".repeat(60));
+    println!("{}", "=".repeat(60));
     
     batch_operations_example(&publisher, &mut subscriber, &format!("{}/batch", base_topic)).await?;
 
@@ -102,7 +102,7 @@ async fn qos0_example(
     
     let message = Message::new(b"Hello from MQTT QoS 0!".to_vec())
         .with_metadata("qos", "0")
-        .with_metadata("timestamp", &chrono::Utc::now().to_rfc3339());
+        .with_metadata("timestamp", chrono::Utc::now().to_rfc3339());
     
     publisher.publish(topic, vec![message.clone()]).await?;
     println!("✅ Message published: {}", String::from_utf8_lossy(&message.payload));
@@ -291,11 +291,9 @@ async fn batch_operations_example(
     // Give time for subscription to be established
     sleep(Duration::from_millis(100)).await;
     
-    let messages = vec![
-        Message::new(b"Batch message 1".to_vec()).with_metadata("batch_id", "1"),
+    let messages = [Message::new(b"Batch message 1".to_vec()).with_metadata("batch_id", "1"),
         Message::new(b"Batch message 2".to_vec()).with_metadata("batch_id", "2"),
-        Message::new(b"Batch message 3".to_vec()).with_metadata("batch_id", "3"),
-    ];
+        Message::new(b"Batch message 3".to_vec()).with_metadata("batch_id", "3")];
     
     // Publish messages individually (MQTT doesn't have native batch publish)
     for (i, message) in messages.iter().enumerate() {
@@ -332,8 +330,5 @@ async fn batch_operations_example(
 }
 
 async fn is_mqtt_available() -> bool {
-    match tokio::net::TcpStream::connect("127.0.0.1:1883").await {
-        Ok(_) => true,
-        Err(_) => false,
-    }
+    (tokio::net::TcpStream::connect("127.0.0.1:1883").await).is_ok()
 }

--- a/kincir/examples/rabbitmq_ack_example.rs
+++ b/kincir/examples/rabbitmq_ack_example.rs
@@ -1,51 +1,49 @@
-//! Kafka Acknowledgment Example
+//! RabbitMQ Acknowledgment Example
 //!
-//! This example demonstrates how to use Apache Kafka with manual acknowledgment handling.
+//! This example demonstrates how to use RabbitMQ with manual acknowledgment handling.
 //! It shows publishing messages, receiving them with acknowledgment handles, and
 //! performing manual acknowledgment or negative acknowledgment operations.
 //!
 //! Prerequisites:
-//! - Apache Kafka server running on localhost:9092
-//! - Topic creation (topics will be auto-created if auto.create.topics.enable=true)
+//! - RabbitMQ server running on localhost:5672
+//! - Default guest/guest credentials
 //!
-//! Run with: cargo run --example kafka_ack_example
+//! Run with: cargo run --example rabbitmq_ack_example
 
 use kincir::ack::{AckHandle, AckSubscriber};
-use kincir::kafka::{KafkaAckSubscriber, KafkaPublisher};
+use kincir::rabbitmq::{RabbitMQAckSubscriber, RabbitMQPublisher};
 use kincir::{Message, Publisher};
 use std::time::Duration;
 use tokio::time::{sleep, timeout};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    println!("🚀 Kafka Acknowledgment Example");
-    println!("=================================");
+    println!("🚀 RabbitMQ Acknowledgment Example");
+    println!("=====================================");
 
-    // Check if Kafka is available
-    if !is_kafka_available().await {
-        eprintln!("❌ Kafka is not available at localhost:9092");
-        eprintln!("   Please start Kafka server and try again.");
-        eprintln!("   Docker: docker run -d --name kafka -p 9092:9092 apache/kafka:latest");
+    // Check if RabbitMQ is available
+    if !is_rabbitmq_available().await {
+        eprintln!("❌ RabbitMQ is not available at localhost:5672");
+        eprintln!("   Please start RabbitMQ server and try again.");
+        eprintln!("   Docker: docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-management");
         return Ok(());
     }
 
-    println!("✅ Kafka connection available");
+    println!("✅ RabbitMQ connection available");
 
     // Configuration
-    let brokers = vec!["127.0.0.1:9092".to_string()];
-    let topic = "ack-example-topic";
-    let consumer_group = "ack-example-group";
+    let rabbitmq_uri = "amqp://guest:guest@127.0.0.1:5672";
+    let topic = "ack-example-queue";
 
     // Create publisher
-    println!("\n📤 Creating Kafka publisher...");
-    let publisher = KafkaPublisher::new(brokers.clone())?;
+    println!("\n📤 Creating RabbitMQ publisher...");
+    let publisher = RabbitMQPublisher::new(rabbitmq_uri).await?;
     println!("✅ Publisher created successfully");
 
     // Create subscriber with acknowledgment support
-    println!("\n📥 Creating Kafka acknowledgment subscriber...");
-    let mut subscriber = KafkaAckSubscriber::new(brokers, consumer_group.to_string()).await?;
+    println!("\n📥 Creating RabbitMQ acknowledgment subscriber...");
+    let mut subscriber = RabbitMQAckSubscriber::new(rabbitmq_uri).await?;
     println!("✅ Acknowledgment subscriber created successfully");
-    println!("   Consumer Group: {}", subscriber.group_id());
 
     // Subscribe to topic
     println!("\n🔗 Subscribing to topic: {}", topic);
@@ -53,57 +51,57 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("✅ Successfully subscribed to topic");
 
     // Example 1: Basic acknowledgment
-    println!("\n" + "=".repeat(50).as_str());
+    println!("\n{}", "=".repeat(50));
     println!("📋 Example 1: Basic Message Acknowledgment");
-    println!("=".repeat(50));
+    println!("{}", "=".repeat(50));
     
     basic_acknowledgment_example(&publisher, &mut subscriber, topic).await?;
 
     // Example 2: Negative acknowledgment with requeue
-    println!("\n" + "=".repeat(50).as_str());
+    println!("\n{}", "=".repeat(50));
     println!("📋 Example 2: Negative Acknowledgment with Requeue");
-    println!("=".repeat(50));
+    println!("{}", "=".repeat(50));
     
     negative_acknowledgment_example(&publisher, &mut subscriber, topic).await?;
 
     // Example 3: Batch acknowledgment
-    println!("\n" + "=".repeat(50).as_str());
+    println!("\n{}", "=".repeat(50));
     println!("📋 Example 3: Batch Acknowledgment");
-    println!("=".repeat(50));
+    println!("{}", "=".repeat(50));
     
     batch_acknowledgment_example(&publisher, &mut subscriber, topic).await?;
 
-    // Example 4: Offset management and consumer groups
-    println!("\n" + "=".repeat(50).as_str());
-    println!("📋 Example 4: Offset Management and Consumer Groups");
-    println!("=".repeat(50));
+    // Example 4: Error handling and retry logic
+    println!("\n{}", "=".repeat(50));
+    println!("📋 Example 4: Error Handling and Retry Logic");
+    println!("{}", "=".repeat(50));
     
-    offset_management_example(&publisher, &mut subscriber, topic).await?;
+    error_handling_example(&publisher, &mut subscriber, topic).await?;
 
     println!("\n🎉 All examples completed successfully!");
-    println!("   The Kafka acknowledgment system provides reliable message processing");
-    println!("   with manual control over offset commits and consumer group coordination.");
+    println!("   The RabbitMQ acknowledgment system provides reliable message processing");
+    println!("   with manual control over message acknowledgment and requeue behavior.");
 
     Ok(())
 }
 
 async fn basic_acknowledgment_example(
-    publisher: &KafkaPublisher,
-    subscriber: &mut KafkaAckSubscriber,
+    publisher: &RabbitMQPublisher,
+    subscriber: &mut RabbitMQAckSubscriber,
     topic: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("📤 Publishing message for basic acknowledgment...");
     
-    let message = Message::new(b"Hello from Kafka with acknowledgment!".to_vec())
+    let message = Message::new(b"Hello from RabbitMQ with acknowledgment!".to_vec())
         .with_metadata("example", "basic_ack")
-        .with_metadata("timestamp", &chrono::Utc::now().to_rfc3339());
+        .with_metadata("timestamp", chrono::Utc::now().to_rfc3339());
     
     publisher.publish(topic, vec![message.clone()]).await?;
     println!("✅ Message published: {}", String::from_utf8_lossy(&message.payload));
 
     println!("📥 Receiving message with acknowledgment handle...");
     let (received_message, ack_handle) = timeout(
-        Duration::from_secs(15),
+        Duration::from_secs(10),
         subscriber.receive_with_ack()
     ).await??;
 
@@ -115,22 +113,20 @@ async fn basic_acknowledgment_example(
     println!("📋 Acknowledgment handle details:");
     println!("   Message ID: {}", ack_handle.message_id());
     println!("   Topic: {}", ack_handle.topic());
-    println!("   Partition: {}", ack_handle.partition());
-    println!("   Offset: {}", ack_handle.offset());
     println!("   Delivery Count: {}", ack_handle.delivery_count());
     println!("   Is Retry: {}", ack_handle.is_retry());
     println!("   Handle ID: {}", ack_handle.handle_id());
 
-    println!("✅ Acknowledging message (committing offset)...");
+    println!("✅ Acknowledging message...");
     subscriber.ack(ack_handle).await?;
-    println!("✅ Message acknowledged successfully - offset committed");
+    println!("✅ Message acknowledged successfully");
 
     Ok(())
 }
 
 async fn negative_acknowledgment_example(
-    publisher: &KafkaPublisher,
-    subscriber: &mut KafkaAckSubscriber,
+    publisher: &RabbitMQPublisher,
+    subscriber: &mut RabbitMQAckSubscriber,
     topic: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("📤 Publishing message for negative acknowledgment...");
@@ -144,12 +140,11 @@ async fn negative_acknowledgment_example(
 
     println!("📥 Receiving message...");
     let (received_message, ack_handle) = timeout(
-        Duration::from_secs(15),
+        Duration::from_secs(10),
         subscriber.receive_with_ack()
     ).await??;
 
     println!("✅ Message received: {}", String::from_utf8_lossy(&received_message.payload));
-    println!("   Partition: {}, Offset: {}", ack_handle.partition(), ack_handle.offset());
 
     // Simulate processing failure
     let should_process = received_message.metadata.get("should_process")
@@ -159,9 +154,10 @@ async fn negative_acknowledgment_example(
     if !should_process {
         println!("❌ Processing failed - negatively acknowledging with requeue...");
         subscriber.nack(ack_handle, true).await?;
-        println!("✅ Message negatively acknowledged (offset NOT committed)");
-        println!("💡 Message will be redelivered on consumer restart or rebalance");
-        println!("   In Kafka, 'requeue' means we don't commit the offset");
+        println!("✅ Message negatively acknowledged and requeued");
+        
+        // The message is now back in the queue and could be received again
+        println!("💡 Message has been requeued and is available for reprocessing");
     } else {
         println!("✅ Processing successful - acknowledging...");
         subscriber.ack(ack_handle).await?;
@@ -171,8 +167,8 @@ async fn negative_acknowledgment_example(
 }
 
 async fn batch_acknowledgment_example(
-    publisher: &KafkaPublisher,
-    subscriber: &mut KafkaAckSubscriber,
+    publisher: &RabbitMQPublisher,
+    subscriber: &mut RabbitMQAckSubscriber,
     topic: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("📤 Publishing batch of messages...");
@@ -191,85 +187,86 @@ async fn batch_acknowledgment_example(
     
     for i in 0..messages.len() {
         let (received_message, ack_handle) = timeout(
-            Duration::from_secs(15),
+            Duration::from_secs(10),
             subscriber.receive_with_ack()
         ).await??;
         
-        println!("✅ Received message {}: {} (partition: {}, offset: {})", 
+        println!("✅ Received message {}: {}", 
                 i + 1, 
-                String::from_utf8_lossy(&received_message.payload),
-                ack_handle.partition(),
-                ack_handle.offset());
+                String::from_utf8_lossy(&received_message.payload));
         
         ack_handles.push(ack_handle);
     }
 
     println!("📋 Performing batch acknowledgment for {} messages...", ack_handles.len());
-    println!("   Kafka will commit the highest offset for each partition");
-    
     subscriber.ack_batch(ack_handles).await?;
     println!("✅ Batch acknowledgment completed successfully");
-    println!("💡 All messages in the batch were acknowledged with optimized offset commits");
+    println!("💡 All messages in the batch were acknowledged with a single operation");
 
     Ok(())
 }
 
-async fn offset_management_example(
-    publisher: &KafkaPublisher,
-    subscriber: &mut KafkaAckSubscriber,
+async fn error_handling_example(
+    publisher: &RabbitMQPublisher,
+    subscriber: &mut RabbitMQAckSubscriber,
     topic: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    println!("📤 Publishing messages for offset management demonstration...");
+    println!("📤 Publishing message for error handling demonstration...");
     
-    let messages = vec![
-        Message::new(b"Offset message 1".to_vec()).with_metadata("process", "true"),
-        Message::new(b"Offset message 2".to_vec()).with_metadata("process", "false"),
-        Message::new(b"Offset message 3".to_vec()).with_metadata("process", "true"),
-    ];
+    let message = Message::new(b"Message for error handling".to_vec())
+        .with_metadata("simulate_error", "true")
+        .with_metadata("max_retries", "3");
     
-    publisher.publish(topic, messages.clone()).await?;
-    println!("✅ Published {} messages for offset management", messages.len());
+    publisher.publish(topic, vec![message.clone()]).await?;
+    println!("✅ Message published: {}", String::from_utf8_lossy(&message.payload));
 
-    println!("📥 Processing messages with selective acknowledgment...");
+    println!("📥 Receiving message and simulating processing with retries...");
     
-    for i in 0..messages.len() {
+    let mut retry_count = 0;
+    let max_retries = 3;
+    
+    loop {
         let (received_message, ack_handle) = timeout(
-            Duration::from_secs(15),
+            Duration::from_secs(10),
             subscriber.receive_with_ack()
         ).await??;
 
-        println!("🔄 Processing message {} at offset {}", i + 1, ack_handle.offset());
+        retry_count += 1;
+        println!("🔄 Processing attempt {} of {}", retry_count, max_retries);
         
-        // Simulate processing based on metadata
-        let should_process = received_message.metadata.get("process")
+        // Simulate processing
+        let simulate_error = received_message.metadata.get("simulate_error")
             .map(|v| v == "true")
             .unwrap_or(false);
 
-        if should_process {
-            println!("✅ Processing successful - acknowledging offset {}", ack_handle.offset());
-            subscriber.ack(ack_handle).await?;
-        } else {
-            println!("❌ Processing failed - discarding message at offset {}", ack_handle.offset());
-            // Discard by committing offset (skip this message)
+        if simulate_error && retry_count < max_retries {
+            println!("❌ Processing failed (simulated) - attempt {}", retry_count);
+            println!("🔄 Negatively acknowledging with requeue for retry...");
+            subscriber.nack(ack_handle, true).await?;
+            
+            // Add delay before retry
+            sleep(Duration::from_millis(500)).await;
+            continue;
+        } else if simulate_error && retry_count >= max_retries {
+            println!("❌ Max retries exceeded - negatively acknowledging without requeue");
+            println!("💀 Message will be discarded or sent to dead letter queue");
             subscriber.nack(ack_handle, false).await?;
+            break;
+        } else {
+            println!("✅ Processing successful - acknowledging message");
+            subscriber.ack(ack_handle).await?;
+            break;
         }
-        
-        // Small delay to demonstrate sequential processing
-        sleep(Duration::from_millis(100)).await;
     }
 
-    println!("📊 Offset management completed:");
-    println!("   Consumer group: {}", subscriber.group_id());
-    println!("   Topic: {}", topic);
-    println!("💡 Kafka tracks committed offsets per consumer group and partition");
-    println!("   This enables reliable message processing and consumer failover");
+    println!("📊 Error handling completed:");
+    println!("   Total attempts: {}", retry_count);
+    println!("   Max retries: {}", max_retries);
+    println!("💡 This demonstrates how to implement retry logic with acknowledgments");
 
     Ok(())
 }
 
-async fn is_kafka_available() -> bool {
-    match tokio::net::TcpStream::connect("127.0.0.1:9092").await {
-        Ok(_) => true,
-        Err(_) => false,
-    }
+async fn is_rabbitmq_available() -> bool {
+    (tokio::net::TcpStream::connect("127.0.0.1:5672").await).is_ok()
 }

--- a/kincir/examples/router_ack_example.rs
+++ b/kincir/examples/router_ack_example.rs
@@ -6,7 +6,8 @@
 //!
 //! Run with: cargo run --example router_ack_example
 
-use kincir::ack::{AckHandle, AckSubscriber};
+use kincir::ack::AckSubscriber;
+use kincir::adapter::PublisherExt;
 use kincir::memory::{InMemoryAckSubscriber, InMemoryBroker, InMemoryPublisher};
 use kincir::router::{AckRouter, AckStrategy, RouterAckConfig};
 use kincir::{Message, Publisher};
@@ -24,37 +25,37 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let broker = Arc::new(InMemoryBroker::with_default_config());
     
     // Example 1: Basic acknowledgment-aware routing
-    println!("\n" + "=".repeat(60).as_str());
+    println!("\n{}", "=".repeat(60));
     println!("📋 Example 1: Basic Acknowledgment-Aware Routing");
-    println!("=".repeat(60));
+    println!("{}", "=".repeat(60));
     
     basic_ack_routing_example(broker.clone()).await?;
 
     // Example 2: Error handling and retry logic
-    println!("\n" + "=".repeat(60).as_str());
+    println!("\n{}", "=".repeat(60));
     println!("📋 Example 2: Error Handling and Retry Logic");
-    println!("=".repeat(60));
+    println!("{}", "=".repeat(60));
     
     error_handling_example(broker.clone()).await?;
 
     // Example 3: Different acknowledgment strategies
-    println!("\n" + "=".repeat(60).as_str());
+    println!("\n{}", "=".repeat(60));
     println!("📋 Example 3: Different Acknowledgment Strategies");
-    println!("=".repeat(60));
+    println!("{}", "=".repeat(60));
     
     acknowledgment_strategies_example(broker.clone()).await?;
 
     // Example 4: Processing timeout handling
-    println!("\n" + "=".repeat(60).as_str());
+    println!("\n{}", "=".repeat(60));
     println!("📋 Example 4: Processing Timeout Handling");
-    println!("=".repeat(60));
+    println!("{}", "=".repeat(60));
     
     timeout_handling_example(broker.clone()).await?;
 
     // Example 5: Statistics and monitoring
-    println!("\n" + "=".repeat(60).as_str());
+    println!("\n{}", "=".repeat(60));
     println!("📋 Example 5: Statistics and Monitoring");
-    println!("=".repeat(60));
+    println!("{}", "=".repeat(60));
     
     statistics_example(broker.clone()).await?;
 
@@ -71,13 +72,13 @@ async fn basic_ack_routing_example(
     println!("📤 Setting up basic acknowledgment-aware router...");
 
     // Create components
-    let input_publisher = Arc::new(InMemoryPublisher::new(broker.clone()));
-    let output_publisher = Arc::new(InMemoryPublisher::new(broker.clone()));
+    let input_publisher = Arc::new(InMemoryPublisher::new(broker.clone()).boxed());
+    let output_publisher = Arc::new(InMemoryPublisher::new(broker.clone()).boxed());
     let subscriber = Arc::new(Mutex::new(InMemoryAckSubscriber::new(broker.clone())));
     let output_subscriber = Arc::new(Mutex::new(InMemoryAckSubscriber::new(broker.clone())));
 
     // Create a simple message processing handler
-    let handler = Arc::new(|msg: Message| {
+    let handler: kincir::router::HandlerFunc = Arc::new(|msg: Message| {
         Box::pin(async move {
             println!("  🔄 Processing message: {}", String::from_utf8_lossy(&msg.payload));
             
@@ -85,7 +86,7 @@ async fn basic_ack_routing_example(
             let processed_payload = format!("PROCESSED: {}", String::from_utf8_lossy(&msg.payload));
             let processed_msg = Message::new(processed_payload.into_bytes())
                 .with_metadata("processed", "true")
-                .with_metadata("processed_at", &chrono::Utc::now().to_rfc3339())
+                .with_metadata("processed_at", chrono::Utc::now().to_rfc3339())
                 .with_metadata("original_id", &msg.uuid);
             
             Ok(vec![processed_msg])
@@ -118,16 +119,14 @@ async fn basic_ack_routing_example(
 
     // Subscribe to output topic to see processed messages
     {
-        let mut output_sub = output_subscriber.lock().await;
+        let output_sub = output_subscriber.lock().await;
         output_sub.subscribe("output").await?;
     }
 
     // Publish test messages
-    let test_messages = vec![
-        Message::new(b"Hello Router!".to_vec()).with_metadata("priority", "high"),
+    let test_messages = [Message::new(b"Hello Router!".to_vec()).with_metadata("priority", "high"),
         Message::new(b"Message 2".to_vec()).with_metadata("priority", "normal"),
-        Message::new(b"Message 3".to_vec()).with_metadata("priority", "low"),
-    ];
+        Message::new(b"Message 3".to_vec()).with_metadata("priority", "low")];
 
     for (i, message) in test_messages.iter().enumerate() {
         input_publisher.publish("input", vec![message.clone()]).await?;
@@ -174,12 +173,12 @@ async fn error_handling_example(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("📤 Setting up error handling example...");
 
-    let input_publisher = Arc::new(InMemoryPublisher::new(broker.clone()));
-    let output_publisher = Arc::new(InMemoryPublisher::new(broker.clone()));
+    let input_publisher = Arc::new(InMemoryPublisher::new(broker.clone()).boxed());
+    let output_publisher = Arc::new(InMemoryPublisher::new(broker.clone()).boxed());
     let subscriber = Arc::new(Mutex::new(InMemoryAckSubscriber::new(broker.clone())));
 
     // Handler that fails for messages containing "fail"
-    let handler = Arc::new(|msg: Message| {
+    let handler: kincir::router::HandlerFunc = Arc::new(|msg: Message| {
         Box::pin(async move {
             let payload_str = String::from_utf8_lossy(&msg.payload);
             println!("  🔄 Processing message: {}", payload_str);
@@ -232,12 +231,10 @@ async fn error_handling_example(
     );
 
     // Test messages - some will succeed, some will fail
-    let test_messages = vec![
-        Message::new(b"Success message 1".to_vec()),
+    let test_messages = [Message::new(b"Success message 1".to_vec()),
         Message::new(b"This will fail".to_vec()),
         Message::new(b"Success message 2".to_vec()),
-        Message::new(b"Another fail message".to_vec()),
-    ];
+        Message::new(b"Another fail message".to_vec())];
 
     for (i, message) in test_messages.iter().enumerate() {
         input_publisher.publish("input", vec![message.clone()]).await?;
@@ -282,12 +279,12 @@ async fn acknowledgment_strategies_example(
     for (strategy, strategy_name) in strategies {
         println!("\n🔧 Testing strategy: {}", strategy_name);
 
-        let input_publisher = Arc::new(InMemoryPublisher::new(broker.clone()));
-        let output_publisher = Arc::new(InMemoryPublisher::new(broker.clone()));
+        let input_publisher = Arc::new(InMemoryPublisher::new(broker.clone()).boxed());
+        let output_publisher = Arc::new(InMemoryPublisher::new(broker.clone()).boxed());
         let subscriber = Arc::new(Mutex::new(InMemoryAckSubscriber::new(broker.clone())));
 
         // Handler that always fails for this test
-        let handler = Arc::new(|_msg: Message| {
+        let handler: kincir::router::HandlerFunc = Arc::new(|_msg: Message| {
             Box::pin(async move {
                 Err(Box::new(std::io::Error::new(
                     std::io::ErrorKind::Other,
@@ -376,12 +373,12 @@ async fn timeout_handling_example(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("📤 Setting up timeout handling example...");
 
-    let input_publisher = Arc::new(InMemoryPublisher::new(broker.clone()));
-    let output_publisher = Arc::new(InMemoryPublisher::new(broker.clone()));
+    let input_publisher = Arc::new(InMemoryPublisher::new(broker.clone()).boxed());
+    let output_publisher = Arc::new(InMemoryPublisher::new(broker.clone()).boxed());
     let subscriber = Arc::new(Mutex::new(InMemoryAckSubscriber::new(broker.clone())));
 
     // Handler that takes longer than the timeout
-    let handler = Arc::new(|msg: Message| {
+    let handler: kincir::router::HandlerFunc = Arc::new(|msg: Message| {
         Box::pin(async move {
             let payload_str = String::from_utf8_lossy(&msg.payload);
             println!("  🔄 Starting slow processing: {}", payload_str);
@@ -458,12 +455,12 @@ async fn statistics_example(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("📤 Setting up comprehensive statistics example...");
 
-    let input_publisher = Arc::new(InMemoryPublisher::new(broker.clone()));
-    let output_publisher = Arc::new(InMemoryPublisher::new(broker.clone()));
+    let input_publisher = Arc::new(InMemoryPublisher::new(broker.clone()).boxed());
+    let output_publisher = Arc::new(InMemoryPublisher::new(broker.clone()).boxed());
     let subscriber = Arc::new(Mutex::new(InMemoryAckSubscriber::new(broker.clone())));
 
     // Handler with variable processing times
-    let handler = Arc::new(|msg: Message| {
+    let handler: kincir::router::HandlerFunc = Arc::new(|msg: Message| {
         Box::pin(async move {
             let payload_str = String::from_utf8_lossy(&msg.payload);
             
@@ -514,16 +511,14 @@ async fn statistics_example(
     );
 
     // Publish various test messages
-    let test_messages = vec![
-        Message::new(b"fast message 1".to_vec()),
+    let test_messages = [Message::new(b"fast message 1".to_vec()),
         Message::new(b"normal message 1".to_vec()),
         Message::new(b"slow message 1".to_vec()),
         Message::new(b"fast message 2".to_vec()),
         Message::new(b"fail message 1".to_vec()),
         Message::new(b"normal message 2".to_vec()),
         Message::new(b"fail message 2".to_vec()),
-        Message::new(b"slow message 2".to_vec()),
-    ];
+        Message::new(b"slow message 2".to_vec())];
 
     for (i, message) in test_messages.iter().enumerate() {
         input_publisher.publish("input", vec![message.clone()]).await?;


### PR DESCRIPTION
## Summary

The README's code examples predated the 0.2 API and no longer matched the crate. Since README snippets aren't compiled, they had drifted in several places. I corrected every snippet against the real signatures — verified using the working example crates and a throwaway compile-check of the zero-dependency snippets.

## Corrections

- **Acknowledgments**: switched to the zero-dependency in-memory ack subscriber and acknowledged via `subscriber.ack(handle)` / `subscriber.nack(handle, requeue)` instead of the non-existent `handle.ack()`; noted the same `AckSubscriber` trait covers RabbitMQ/Kafka/MQTT.
- **MQTT**: constructors take `(broker_url, topic[, qos])` and return `Result`; removed the non-existent `publish_with_qos` and the `rumqttc::QoS` import (now `kincir::mqtt::QoS`).
- **Router**: import `StdLogger` from `kincir::logging` (not `kincir::router`), RabbitMQ constructors are `async`/`Result`, subscriber wrapped in `Arc<Mutex<..>>`, handler typed as `HandlerFunc`, and the handler uses the consuming `Message::with_metadata` builder.
- **RabbitMQ/Kafka backend snippets**: async single-arg RabbitMQ constructors; `KafkaPublisher::new(vec![..])` returning `Result`.
- **Generic subscribe example**: `receive()` requires `&mut self`.
- Replaced the non-existent `Message::set_metadata` with `with_metadata`.

## Testing

- Verified the in-memory and acknowledgment snippets compile via a temporary example (since removed).
- The backend (MQTT/RabbitMQ/Kafka/Router) snippets mirror the compiling `examples/*` crates.
- Confirmed no residual `publish_with_qos` / `set_metadata` / `rumqttc::QoS` / two-arg `RabbitMQAckSubscriber::new` / `handle.ack()` patterns remain.

## Notes

- Documentation only; no source changes.
- Deliberately did **not** advertise NATS as a working backend — its `Subscriber::receive` is still an unimplemented stub.