### PR TITLE
Implement a working NATS subscriber

### DIFF
--- a/kincir/src/nats/mod.rs
+++ b/kincir/src/nats/mod.rs
@@ -5,7 +5,10 @@
 use crate::{Message, Publisher, Subscriber};
 use async_nats::Client;
 use async_trait::async_trait;
+use futures::StreamExt;
+use std::sync::Arc;
 use thiserror::Error;
+use tokio::sync::Mutex;
 
 #[derive(Error, Debug)]
 pub enum NatsError {
@@ -55,9 +58,14 @@ impl Publisher for NatsPublisher {
 }
 
 /// NATS Subscriber
+///
+/// A subscription is created by [`Subscriber::subscribe`] and consumed
+/// message-by-message via [`Subscriber::receive`]. The active subscription is
+/// held behind a mutex so the `&self` `subscribe` and `&mut self` `receive`
+/// methods can share it.
 pub struct NatsSubscriber {
-    #[allow(dead_code)] // retained to keep the NATS connection alive for the subscriber's lifetime
     client: Client,
+    subscription: Arc<Mutex<Option<async_nats::Subscriber>>>,
 }
 
 impl NatsSubscriber {
@@ -65,8 +73,11 @@ impl NatsSubscriber {
         let client = async_nats::connect(url)
             .await
             .map_err(|e| NatsError::ConnectionError(e.to_string()))?;
-        
-        Ok(Self { client })
+
+        Ok(Self {
+            client,
+            subscription: Arc::new(Mutex::new(None)),
+        })
     }
 }
 
@@ -75,17 +86,33 @@ impl Subscriber for NatsSubscriber {
     type Error = Box<dyn std::error::Error + Send + Sync>;
 
     async fn subscribe(&self, topic: &str) -> Result<(), Self::Error> {
-        // NATS subscription is done per-message in receive
-        let _ = topic;
+        let subscription = self
+            .client
+            .subscribe(topic.to_string())
+            .await
+            .map_err(|e| NatsError::SubscribeError(e.to_string()))?;
+
+        // Replace any previous subscription with the new one.
+        *self.subscription.lock().await = Some(subscription);
         Ok(())
     }
 
     async fn receive(&mut self) -> Result<Message, Self::Error> {
-        // For NATS, we'd need to set up a subscription first
-        // This is a simplified implementation
-        Err(Box::new(NatsError::ReceiveError(
-            "NATS receive not fully implemented - use subscription via client".to_string()
-        )))
+        let mut guard = self.subscription.lock().await;
+        let subscription = guard.as_mut().ok_or_else(|| {
+            NatsError::ReceiveError("not subscribed: call subscribe() first".to_string())
+        })?;
+
+        match subscription.next().await {
+            Some(nats_message) => {
+                let message = Message::new(nats_message.payload.to_vec())
+                    .with_metadata("nats_subject", nats_message.subject.to_string());
+                Ok(message)
+            }
+            None => Err(Box::new(NatsError::ReceiveError(
+                "subscription closed".to_string(),
+            ))),
+        }
     }
 }
 

--- a/kincir/tests/nats_integration_tests.rs
+++ b/kincir/tests/nats_integration_tests.rs
@@ -29,3 +29,59 @@ mod tests {
         assert_eq!(message.payload, payload);
     }
 }
+
+
+/// Tests that require a running NATS server. Enabled with the
+/// `broker-integration` feature so they are compile-checked but do not run in
+/// the default test suite. Run with:
+///   cargo test -p kincir --features broker-integration --test nats_integration_tests
+#[cfg(feature = "broker-integration")]
+mod broker_tests {
+    use kincir::nats::{NatsPublisher, NatsSubscriber};
+    use kincir::{Message, Publisher, Subscriber};
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    fn nats_url() -> String {
+        std::env::var("NATS_URL").unwrap_or_else(|_| "nats://localhost:4222".to_string())
+    }
+
+    #[tokio::test]
+    async fn test_nats_publish_subscribe_roundtrip() {
+        let url = nats_url();
+        let publisher = NatsPublisher::new(&url).await.expect("connect publisher");
+        let mut subscriber = NatsSubscriber::new(&url).await.expect("connect subscriber");
+
+        let subject = "kincir.test.roundtrip";
+        subscriber.subscribe(subject).await.expect("subscribe");
+
+        // Give the subscription a moment to register on the server before publishing.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let payload = b"hello nats".to_vec();
+        publisher
+            .publish(subject, vec![Message::new(payload.clone())])
+            .await
+            .expect("publish");
+
+        let received = timeout(Duration::from_secs(5), subscriber.receive())
+            .await
+            .expect("receive timed out")
+            .expect("receive failed");
+
+        assert_eq!(received.payload, payload);
+        assert_eq!(
+            received.metadata.get("nats_subject").map(|s| s.as_str()),
+            Some(subject)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_nats_receive_without_subscribe_errors() {
+        let url = nats_url();
+        let mut subscriber = NatsSubscriber::new(&url).await.expect("connect subscriber");
+
+        // Receiving before subscribing should return an error, not panic.
+        assert!(subscriber.receive().await.is_err());
+    }
+}


### PR DESCRIPTION

## Summary

The NATS backend could publish but not consume: `NatsSubscriber::receive` was a stub that always returned a `ReceiveError("not fully implemented")`. This implements a real subscriber on top of the async-nats subscription stream.

## Changes

- **`Subscriber` for `NatsSubscriber`**:
  - `subscribe(&self, topic)` creates an `async_nats` subscription and stores it behind a `Mutex<Option<..>>` so the `&self` `subscribe` and `&mut self` `receive` can share it (mirrors how the other backends manage subscription state).
  - `receive(&mut self)` pulls the next message off the subscription stream (`futures::StreamExt`), maps it to a kincir `Message`, and records the source subject in metadata under `nats_subject`.
  - Calling `receive()` before `subscribe()` now returns a clear error instead of an unconditional “not implemented” error.
  - The `client` field is now actually used (dropped the `#[allow(dead_code)]`).
- **Tests**: added broker-gated integration tests (publish/subscribe roundtrip + the receive-before-subscribe error path) under the existing `broker-integration` feature, so they’re compile-checked by default and runnable against a real NATS server with `cargo test -p kincir --features broker-integration`.

## Testing

- `cargo build -p kincir`: clean.
- `cargo clippy -p kincir --all-targets`: clean (default and `--features broker-integration`).
- `cargo test -p kincir`: full suite green (NATS unit tests pass; broker-gated tests excluded by default).
- `cargo test -p kincir --features broker-integration --no-run`: the NATS integration tests compile.

## Notes

- The roundtrip integration test requires a running NATS server (defaults to `nats://localhost:4222`, overridable via `NATS_URL`); it is feature-gated so it does not run in the default suite.
- Follow-up: the README/feature list can now legitimately mention NATS as a working backend (left out here to keep this PR focused on the implementation).